### PR TITLE
[Feature] Improve blobpathresolver to uniquely resolve type names generics namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Built with .NET 8, following Clean Architecture and SOLID principles, it empower
 Install via CLI:
 
 ```bash
-dotnet add package CloudStorageORM --version 0.1.4-beta
+dotnet add package CloudStorageORM --version 0.1.7-beta
 ```
 
 Or search for `CloudStorageORM` in the NuGet Package Manager inside Visual Studio.
@@ -57,7 +57,7 @@ var context = new CloudStorageDbContext(options, storageProvider);
 var users = await context.Set<User>().ToListAsync();
 ```
 
-![SampleApp](https://github.com/user-attachments/assets/4184b418-23bf-4371-a636-7cef41b8f1f9)
+![SampleApp](https://github.com/user-attachments/assets/4727df94-c149-46ae-a359-da159fe5c8b6)
 ```csharp
 using CloudStorageORM.DbContext;
 using CloudStorageORM.Enums;

--- a/src/CloudStorageORM/Azure/StorageProviders/AzureBlobStorageProvider.cs
+++ b/src/CloudStorageORM/Azure/StorageProviders/AzureBlobStorageProvider.cs
@@ -1,6 +1,7 @@
 ﻿namespace CloudStorageORM.Azure.StorageProviders
 {
     using System.Collections.Generic;
+    using System.Text;
     using System.Text.Json;
     using System.Threading.Tasks;
     using CloudStorageORM.Interfaces.StorageProviders;
@@ -88,6 +89,19 @@
         public async Task CreateContainerIfNotExistsAsync()
         {
             await _containerClient.CreateIfNotExistsAsync();
+        }
+
+        public string SanitizeBlobName(string rawName)
+        {
+            var invalidChars = new[] { '\\', '/', '?', '#', '[', ']', ' ', '+', '`', '"' };
+            var sanitizedName = new StringBuilder(rawName.Length);
+
+            foreach (var c in rawName)
+            {
+                sanitizedName.Append(invalidChars.Contains(c) ? '_' : c);
+            }
+
+            return sanitizedName.ToString().ToLowerInvariant();
         }
     }
 }

--- a/src/CloudStorageORM/Infrastructure/BlobPathResolver.cs
+++ b/src/CloudStorageORM/Infrastructure/BlobPathResolver.cs
@@ -2,19 +2,80 @@
 {
     using System;
     using System.Linq;
-    using CloudStorageORM.Abstractions;
+    using System.Security.Cryptography;
+    using System.Text;
     using CloudStorageORM.Interfaces.Infrastructure;
+    using CloudStorageORM.Interfaces.StorageProviders;
     using Microsoft.EntityFrameworkCore.Update;
 
     public class BlobPathResolver : IBlobPathResolver
     {
+        private readonly IStorageProvider _storageProvider;
+
+        public BlobPathResolver(
+            IStorageProvider storageProvider)
+        {
+            _storageProvider = storageProvider ?? throw new ArgumentNullException(nameof(storageProvider));
+        }
+
         public string GetBlobName(Type type)
         {
-            var blobAttr = type.GetCustomAttributes(typeof(BlobSettingsAttribute), false)
-                               .Cast<BlobSettingsAttribute>()
-                               .FirstOrDefault();
+            var name = type.Name.ToLowerInvariant();
+            var hashSource = GetFullTypeName(type);
+            var hash = GetDeterministicHash(hashSource);
 
-            return blobAttr?.Name ?? type.Name.ToLowerInvariant().Trim();
+            return $"{Sanitize(hash)}-{Sanitize(name)}";
+        }
+
+        private static string GetFullTypeName(Type type)
+        {
+            if (!type.IsGenericType)
+            {
+                return type.FullName ?? type.Name;
+            }
+
+            var genericTypeName = type.GetGenericTypeDefinition().FullName ?? type.Name;
+            var genericArgs = string.Join(",", type.GetGenericArguments().Select(GetFullTypeName));
+            return $"{genericTypeName}<{genericArgs}>";
+        }
+
+        private static string GetDeterministicHash(string input)
+        {
+            using var sha = SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes(input);
+            var hash = sha.ComputeHash(bytes);
+
+            return BitConverter
+                .ToString(hash)
+                .Replace("-", "")
+                .ToLowerInvariant()
+                .Substring(0, 16);
+        }
+
+        private string Sanitize(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (_storageProvider != null)
+            {
+                return _storageProvider.SanitizeBlobName(SanitizeLocally(name));
+            }
+
+            return SanitizeLocally(name);
+        }
+
+        private static string SanitizeLocally(string name)
+        {
+            return name
+                .ToLower()
+                .Replace(".", "_")
+                .Replace("+", "_")
+                .Replace("`", "_")
+                .Replace("[", "_")
+                .Replace("]", "_");
         }
 
         public string GetPath(IUpdateEntry entry)

--- a/src/CloudStorageORM/Interfaces/StorageProviders/IStorageProvider.cs
+++ b/src/CloudStorageORM/Interfaces/StorageProviders/IStorageProvider.cs
@@ -11,5 +11,6 @@
         Task<T> ReadAsync<T>(string path);
         Task DeleteAsync(string path);
         Task<List<string>> ListAsync(string folderPath);
+        string SanitizeBlobName(string rawName);
     }
 }

--- a/tests/CloudStorageORM.Tests/Infrastructure/BlobPathResolverTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/BlobPathResolverTests.cs
@@ -1,0 +1,198 @@
+﻿namespace CloudStorageORM.Tests.Infrastructure
+{
+    using System.Collections.Generic;
+
+    namespace CloudStorageORM.Tests.Infrastructure
+    {
+        using System;
+        using global::CloudStorageORM.Abstractions;
+        using global::CloudStorageORM.Infrastructure;
+        using global::CloudStorageORM.Interfaces.Infrastructure;
+        using global::CloudStorageORM.Interfaces.StorageProviders;
+        using Microsoft.EntityFrameworkCore.ChangeTracking;
+        using Microsoft.EntityFrameworkCore.Infrastructure;
+        using Microsoft.EntityFrameworkCore.Metadata;
+        using Microsoft.EntityFrameworkCore.Update;
+        using Moq;
+        using Shouldly;
+        using Xunit;
+
+        public class BlobPathResolverTests
+        {
+            private IBlobPathResolver MakeSut(IStorageProvider storageProvider)
+            {
+                return new BlobPathResolver(storageProvider);
+            }
+
+            [Fact]
+            public void GetBlobNameWithBlobSettingsAttribute_UsesCustomName()
+            {
+                var mockProvider = new Mock<IStorageProvider>();
+                mockProvider
+                    .Setup(x => x.SanitizeBlobName(It.IsAny<string>()))
+                    .Returns<string>(s => $"{s}");
+                var sut = MakeSut(mockProvider.Object);
+
+                var result = sut.GetBlobName(typeof(CustomNamedEntity));
+
+                result.ShouldBe("baa75315fcdd71d5-customnamedentity");
+            }
+
+            [Fact]
+            public void GetBlobNameWithoutAttribute_UsesSanitizedTypeName()
+            {
+                var mockProvider = new Mock<IStorageProvider>();
+                mockProvider
+                    .Setup(x => x.SanitizeBlobName(It.IsAny<string>()))
+                    .Returns<string>(s => $"{s}");
+
+                var sut = MakeSut(mockProvider.Object);
+
+                var result = sut.GetBlobName(typeof(GenericEntity<SubType1>));
+
+                result.ShouldBe("ae8110d245d262ef-genericentity_1");
+            }
+
+            [Fact]
+            public void GetBlobNameForTwoSubEntities_ShouldNotCollide()
+            {
+                var mockProvider = new Mock<IStorageProvider>();
+                mockProvider
+                    .Setup(x => x.SanitizeBlobName(It.IsAny<string>()))
+                    .Returns<string>(s => $"{s}");
+
+                var sut = MakeSut(mockProvider.Object);
+
+                var result1 = sut.GetBlobName(typeof(GenericEntity<SubType1>));
+                var result2 = sut.GetBlobName(typeof(GenericEntity<SubType2>));
+
+                result1.Equals(result2).ShouldBe(false);
+            }
+
+            [Fact]
+            public void GetPathWithoutPrimaryKeyValue_ThrowsException()
+            {
+                var mockEntry = new Mock<IUpdateEntry>();
+                var mockType = new Mock<IEntityType>();
+                var mockProperty = new Mock<IProperty>();
+
+                mockType.Setup(x => x.ClrType).Returns(typeof(DummyEntity));
+                mockType.Setup(x => x.FindPrimaryKey()).Returns(new TestKey(mockProperty.Object));
+                mockEntry.Setup(x => x.EntityType).Returns(mockType.Object);
+                mockEntry.Setup(x => x.GetCurrentValue(mockProperty.Object)).Returns(null);
+
+                var mockProvider = new Mock<IStorageProvider>();
+                mockProvider.Setup(x => x.SanitizeBlobName(It.IsAny<string>())).Returns("entity");
+
+                var sut = MakeSut(mockProvider.Object);
+
+                Should.Throw<InvalidOperationException>(() => sut.GetPath(mockEntry.Object))
+                    .Message.ShouldContain("without a valid key value");
+            }
+
+            [Fact]
+            public void GetPathWithValidKey_ReturnsExpectedPath()
+            {
+                var mockEntry = new Mock<IUpdateEntry>();
+                var mockType = new Mock<IEntityType>();
+                var mockProperty = new Mock<IProperty>();
+
+                mockType.Setup(x => x.ClrType).Returns(typeof(DummyEntity));
+                mockType.Setup(x => x.FindPrimaryKey()).Returns(new TestKey(mockProperty.Object));
+                mockEntry.Setup(x => x.EntityType).Returns(mockType.Object);
+                mockEntry.Setup(x => x.GetCurrentValue(mockProperty.Object)).Returns("123");
+
+                var mockProvider = new Mock<IStorageProvider>();
+                mockProvider.Setup(x => x.SanitizeBlobName(It.IsAny<string>())).Returns("dummy_entity");
+
+                var sut = MakeSut(mockProvider.Object);
+
+                var path = sut.GetPath(mockEntry.Object);
+
+                path.ShouldBe("dummy_entity-dummy_entity/123.json");
+            }
+
+            private class TestKey : IKey
+            {
+                public TestKey(params IProperty[] properties) => Properties = properties;
+
+                public object? this[string name] => throw new NotImplementedException();
+
+                public IReadOnlyList<IProperty> Properties { get; }
+
+                public IEntityType DeclaringEntityType => throw new NotImplementedException();
+
+                IReadOnlyList<IReadOnlyProperty> IReadOnlyKey.Properties => Properties;
+
+                IReadOnlyEntityType IReadOnlyKey.DeclaringEntityType => DeclaringEntityType;
+
+                public IAnnotation AddRuntimeAnnotation(string name, object? value)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IAnnotation? FindAnnotation(string name)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IAnnotation? FindRuntimeAnnotation(string name)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IEnumerable<IAnnotation> GetAnnotations()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public TValue GetOrAddRuntimeAnnotationValue<TValue, TArg>(string name, Func<TArg?, TValue> valueFactory, TArg? factoryArgument)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IPrincipalKeyValueFactory<TKey> GetPrincipalKeyValueFactory<TKey>() where TKey : notnull
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IPrincipalKeyValueFactory GetPrincipalKeyValueFactory()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IEnumerable<IReadOnlyForeignKey> GetReferencingForeignKeys()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IEnumerable<IAnnotation> GetRuntimeAnnotations()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IAnnotation? RemoveRuntimeAnnotation(string name)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IAnnotation SetRuntimeAnnotation(string name, object? value)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            [BlobSettings(Name = "custom-name")]
+            private class CustomNamedEntity { }
+
+            private class DummyEntity { }
+
+            private class SubType1 { }
+
+            private class SubType2 { }
+
+            private class GenericEntity<T> { }
+        }
+    }
+
+}

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageDbContextDependencies.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageDbContextDependencies.cs
@@ -1,6 +1,6 @@
 ﻿namespace CloudStorageORM.Tests.Infrastructure
 {
-    using CloudStorageORM.Infrastructure;
+    using global::CloudStorageORM.Infrastructure;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
     using Microsoft.EntityFrameworkCore.Diagnostics;

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageSingletonOptionsInitializerTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageSingletonOptionsInitializerTests.cs
@@ -1,6 +1,6 @@
 ﻿namespace CloudStorageORM.Tests.Infrastructure
 {
-    using CloudStorageORM.Infrastructure;
+    using global::CloudStorageORM.Infrastructure;
     using Microsoft.EntityFrameworkCore.Infrastructure;
     using Moq;
     using Shouldly;


### PR DESCRIPTION
# Pull Request

## 📋 Description
Add blob name sanitization and related tests to avoid collision as well as have a reduced name for blobs.
- Implement `SanitizeBlobName` in `AzureBlobStorageProvider` to handle invalid characters in blob names.
- Update `BlobPathResolver` to use the new sanitization method and add private methods for hashing and local sanitization.
- Modify `IStorageProvider` interface to include `SanitizeBlobName`.
- Refactor namespace declarations in test files for consistency.
- Introduce `BlobPathResolverTests` with unit tests for `GetBlobName` and `GetPath` methods to ensure correct behavior and exception handling.

## 🔎 Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please specify):

## 📚 Checklist
- [x] Code follows project standards
- [x] Tests were added or updated
- [x] Documentation was updated if necessary
- [x] Build and tests are passing
