### PR TITLE
Implement ETag-based concurrency handling and related enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ ScaffoldingReadMe.txt
 # Others
 ~$*
 *~
+.DS_Store
 CodeCoverage/
 coverage/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,10 @@ dotnet format CloudStorageORM.sln --verbosity minimal
 ### Unit + integration tests
 
 ```bash
-dotnet test CloudStorageORM.sln --nologo -v minimal
+./scripts/run-local-ci-tests.sh
 ```
+
+This script mirrors CI startup/test behavior and runs Azurite with `--skipApiVersionCheck` for local compatibility.
 
 ### Integration tests with Azurite
 
@@ -126,7 +128,8 @@ docker run -d \
   -p 10001:10001 \
   -p 10002:10002 \
   --name azurite \
-  mcr.microsoft.com/azure-storage/azurite
+  mcr.microsoft.com/azure-storage/azurite:latest \
+  azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 ```
 
 ### Integration tests with LocalStack (AWS)
@@ -139,7 +142,7 @@ docker run -d \
   --name localstack \
   -e SERVICES=s3 \
   -e AWS_DEFAULT_REGION=us-east-1 \
-  localstack/localstack
+  localstack/localstack:3
 ```
 
 ### Coverage workflow

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,19 +2,18 @@
     <PropertyGroup>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
-
     <ItemGroup>
-        <PackageVersion Include="AWSSDK.S3" Version="4.0.19"/>
-        <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.4"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4"/>
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageVersion Include="Moq" Version="4.20.72"/>
-        <PackageVersion Include="Shouldly" Version="4.3.0"/>
-        <PackageVersion Include="xunit" Version="2.9.2"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
-        <PackageVersion Include="coverlet.msbuild" Version="6.0.4"/>
-        <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
+        <PackageVersion Include="AWSSDK.S3" Version="4.0.21.1" />
+        <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageVersion Include="Moq" Version="4.20.72" />
+        <PackageVersion Include="Shouldly" Version="4.3.0" />
+        <PackageVersion Include="xunit" Version="2.9.3" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+        <PackageVersion Include="coverlet.msbuild" Version="8.0.1" />
+        <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ await db.SaveChangesAsync();
 
 ## 🧪 Running tests locally
 
+### CI-parity local run (recommended)
+
+```bash
+./scripts/run-local-ci-tests.sh
+```
+
+This script mirrors CI by starting Azurite and LocalStack, then running restore, build, and tests with TRX and coverage collection.
+
 ### Start Azurite (Azure integration)
 
 ```bash
@@ -160,7 +168,8 @@ docker run -d \
   -p 10001:10001 \
   -p 10002:10002 \
   --name azurite \
-  mcr.microsoft.com/azure-storage/azurite
+  mcr.microsoft.com/azure-storage/azurite:latest \
+  azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 ```
 
 ### Run the solution tests

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 **Simplify persistence. Embrace scalability. Build the future.**
 
 CloudStorageORM is an Entity Framework-style provider that persists entities into cloud object storage.
-The current `main` branch targets **.NET 10**, uses **EF Core 9**, and currently ships with **Azure Blob Storage** and **AWS S3** providers.
+The current `main` branch targets **.NET 10**, uses **EF Core 9**, and currently ships with **Azure Blob Storage** and *
+*AWS S3** providers.
 Support for **Google Cloud Storage** remains on the roadmap.
 
 ![License](https://img.shields.io/badge/license-GPLv3-blue)
@@ -53,7 +54,8 @@ dotnet restore CloudStorageORM.sln
 
 ## 🚀 Getting started
 
-The current recommended integration pattern is to configure a regular EF Core `DbContext` with `UseCloudStorageOrm(...)`.
+The current recommended integration pattern is to configure a regular EF Core `DbContext` with
+`UseCloudStorageOrm(...)`.
 
 ```csharp
 using CloudStorageORM.Contexts;
@@ -118,18 +120,33 @@ await db.SaveChangesAsync();
 ## 🧭 Important notes for the current branch
 
 - The base context namespace is now `CloudStorageORM.Contexts`.
-- Configuration uses composition on `CloudStorageOptions`: common fields stay on the root, while provider-specific fields are under `storage.Azure` and `storage.Aws`.
+- Configuration uses composition on `CloudStorageOptions`: common fields stay on the root, while provider-specific
+  fields are under `storage.Azure` and `storage.Aws`.
 - `CloudStorageOptions.ConnectionString` was removed; use `storage.Azure.ConnectionString` for Azure configuration.
-- Primary-key query predicates now support direct range-aware loading for `>`, `>=`, `<`, and `<=` in addition to equality-based lookups.
+- Primary-key query predicates now support direct range-aware loading for `>`, `>=`, `<`, and `<=` in addition to
+  equality-based lookups.
 - Coding style is enforced with **file-scoped namespaces** (`namespace X;`).
 - The sample app is covered by an integration test that verifies `dotnet run` exits successfully.
 - Integration fixtures can skip Azure/AWS scenarios when Azurite/LocalStack are unavailable.
-- CloudStorage transaction support now uses a durable transaction journal under `__cloudstorageorm/tx/<transactionId>/manifest.json`.
-- `SaveChanges` during an active transaction stages durable operations in the manifest; `Commit` marks the manifest as committed and replays operations; `Rollback` marks the transaction as aborted.
-- Each transaction has a unique `TransactionId` (`Guid`) and only one active transaction is allowed per `DbContext` instance.
-- On startup of a new transaction manager instance, committed manifests are replayed and finalized (`Completed`), while pre-commit manifests are marked as aborted (`Aborted`).
-- Future versions may add provider-native temporary locking (for example, Azure blob leases and AWS conditional/object-lock strategies) to improve concurrent-writer coordination.
-- `IDatabaseCreator` behavior is still minimal right now: schema-style database lifecycle methods are not fully implemented because object storage does not map 1:1 to relational database creation semantics.
+- CloudStorage transaction support now uses a durable transaction journal under
+  `__cloudstorageorm/tx/<transactionId>/manifest.json`.
+- `SaveChanges` during an active transaction stages durable operations in the manifest; `Commit` marks the manifest as
+  committed and replays operations; `Rollback` marks the transaction as aborted.
+- Each transaction has a unique `TransactionId` (`Guid`) and only one active transaction is allowed per `DbContext`
+  instance.
+- On startup of a new transaction manager instance, committed manifests are replayed and finalized (`Completed`), while
+  pre-commit manifests are marked as aborted (`Aborted`).
+- Opt-in optimistic concurrency is available through object-store ETags. Configure entities with
+  `modelBuilder.Entity<TEntity>().UseObjectETagConcurrency()` (shadow `ETag`) or
+  `UseObjectETagConcurrency(e => e.ETag)` (mapped property).
+- Entities can optionally implement `IETag` to expose the current ETag value after materialization and successful saves;
+  this interface is not required.
+- When ETag concurrency is enabled, updates/deletes use provider-native `If-Match` conditions (Azure Blob and AWS S3)
+  and conflicts are raised as `DbUpdateConcurrencyException`.
+- Future versions may add provider-native temporary locking (for example, Azure blob leases and AWS
+  conditional/object-lock strategies) to improve concurrent-writer coordination.
+- `IDatabaseCreator` behavior is still minimal right now: schema-style database lifecycle methods are not fully
+  implemented because object storage does not map 1:1 to relational database creation semantics.
 
 ---
 
@@ -240,4 +257,5 @@ Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a PR.
 ---
 
 
-> _CloudStorageORM aims to make cloud object storage feel familiar to EF-oriented .NET applications, while staying explicit about the current provider and platform limits._
+> _CloudStorageORM aims to make cloud object storage feel familiar to EF-oriented .NET applications, while staying
+explicit about the current provider and platform limits._

--- a/TODO-LIST
+++ b/TODO-LIST
@@ -6,19 +6,19 @@ This document contains a detailed and structured list of all tasks needed to cre
 
 🏁 Project Setup
 
-- [ ] Create GitHub repository: CloudStorageORM
-- [ ] Add .gitignore for Visual Studio and .NET projects
-- [ ] Add initial README.md and LICENSE
-- [ ] Initialize local Git repository and push to GitHub
-- [ ] Define solution structure (CloudStorageORM.sln) with projects inside a /src folder
+- [x] Create GitHub repository: CloudStorageORM
+- [x] Add .gitignore for Visual Studio and .NET projects
+- [x] Add initial README.md and LICENSE
+- [x] Initialize local Git repository and push to GitHub
+- [x] Define solution structure (CloudStorageORM.sln) with projects inside a /src folder
 
 ⸻
 
 🏗️ Core Project Structure
-- [ ] Create core project: CloudStorageORM (.NET 8 Class Library)
-- [ ] Setup default namespace and folder structure
-- [ ] Create unit test project: CloudStorageORM.Tests (xUnit)
-- [ ] Create sample usage project: CloudStorageORM.SampleApp
+- [x] Create core project: CloudStorageORM (.NET 10 Class Library)
+- [x] Setup default namespace and folder structure
+- [x] Create unit test project: CloudStorageORM.Tests (xUnit)
+- [x] Create sample usage project: CloudStorageORM.SampleApp
 - [ ] Create the following folders:
 	- /Abstractions
 	- /Builders
@@ -51,14 +51,14 @@ Storage Provider Abstractions
 	- SnapshotAsync
 
 Implement Providers
-- [ ] Implement AzureBlobStorageProvider
+- [x] Implement AzureBlobStorageProvider
 	- Connect to Azure Blob
 	- Implement Save
 	- Implement Read
 	- Implement Delete
 	- Implement List
 	- Implement lease-based locking
-[ ] Implement AwsS3StorageProvider
+- [x] Implement AwsS3StorageProvider
 	- Connect to AWS S3
 	- Implement Save
 	- Implement Read
@@ -83,11 +83,11 @@ Repository Abstractions
 - [ ] Create IUnitOfWork interface
 
 Implement Repository Pattern
-- [ ] Create CloudStorageRepository<TEntity>
+- [x] Create CloudStorageRepository<TEntity>
 - [ ] Create CloudStorageUnitOfWork
 
 Entity Framework Integration
-- [ ] Create CloudStorageDbContext inheriting DbContext
+- [x] Create CloudStorageDbContext inheriting DbContext
 - [ ] Override SaveChangesAsync to persist to storage
 - [ ] Override Set to load from storage
 
@@ -98,21 +98,21 @@ Builder Pattern
 ⸻
 
 ✅ Unit Testing
-- [ ] Create unit tests for CloudStorageOptions
+- [x] Create unit tests for CloudStorageOptions
 - [ ] Create unit tests for IStorageProvider interface
-- [ ] Create unit tests for CloudStorageRepository
-- [ ] Create unit tests for CloudStorageDbContext
+- [x] Create unit tests for CloudStorageRepository
+- [x] Create unit tests for CloudStorageDbContext
 - [ ] Mock Azure, AWS, and Google providers
 
 ⸻
 
 🧪 Integration Testing
-- [ ] Set up integration testing environments
-- [ ] Azure Storage Emulator or real storage account
-- [ ] AWS S3 Bucket for testing
+- [x] Set up integration testing environments
+- [x] Azure Storage Emulator or real storage account
+- [x] AWS S3 Bucket for testing
 - [ ] Google Storage Bucket for testing
 - [ ] Create integration tests:
-- [ ] Save and Read objects
+- [x] Save and Read objects
 - [ ] Lock and Unlock flows
 - [ ] Snapshot validation
 - [ ] Concurrency handling
@@ -120,9 +120,9 @@ Builder Pattern
 ⸻
 
 📃 Documentation
-- [ ] Extend README.md
-- [ ] Add badges (NuGet, Build, License)
-- [ ] Add quickstart examples
+- [x] Extend README.md
+- [x] Add badges (NuGet, Build, License)
+- [x] Add quickstart examples
 - [ ] Create docs/architecture.md
 - [ ] Explain project layering and Clean Architecture adherence
 - [ ] Create docs/getting-started.md
@@ -135,8 +135,8 @@ Builder Pattern
 
 📦 Publishing
 - [ ] Create nuget.config file if needed
-- [ ] Create .csproj package settings (version, description, tags)
-- [ ] Configure GitHub Actions CI:
+- [x] Create .csproj package settings (version, description, tags)
+- [x] Configure GitHub Actions CI:
 	- Build project
 	- Run unit tests
 	- Pack NuGet package
@@ -147,13 +147,13 @@ Builder Pattern
 
 🚀 Launch and Maintenance
 - [ ] Create GitHub Discussions for Q&A and ideas
-- [ ] Create GitHub Issues templates:
+- [x] Create GitHub Issues templates:
 	- Bug report template
 	- Feature request template
 	- Create Pull Request templates
 	- Add Code of Conduct and Contributing Guidelines
 	- Monitor GitHub issues and respond to community
-- [ ] Plan roadmap for:
+- [x] Plan roadmap for:
 	- Encryption support (optional)
 	- Metadata-based indexing
 	- Cross-provider replication (future idea)

--- a/docs/CloudStorageORM.md
+++ b/docs/CloudStorageORM.md
@@ -75,6 +75,18 @@ Adds related services to DI through:
 
 - `AddEntityFrameworkCloudStorageOrm(this IServiceCollection services, CloudStorageOptions storageOptions)`
 
+### `CloudStorageORM.Extensions.ModelBuilderExtensions`
+
+Adds opt-in object-store ETag optimistic concurrency:
+
+- `UseObjectETagConcurrency()` configures a shadow `ETag` property as a concurrency token.
+- `UseObjectETagConcurrency(e => e.ETag)` configures a mapped property as the concurrency token.
+
+Optional entity convenience contract:
+
+- `CloudStorageORM.Abstractions.IETag` with `string? ETag { get; set; }`.
+- The interface is optional; shadow-property tracking is the default behavior.
+
 ### `CloudStorageORM.Providers.ProviderFactory`
 
 Current behavior:
@@ -98,10 +110,19 @@ Transaction behavior on the current branch:
 
 - `BeginTransaction()` opens a context-scoped transaction manager.
 - Every transaction gets a unique `TransactionId` (`Guid`).
-- `SaveChanges()` inside an active transaction appends staged operations to `__cloudstorageorm/tx/<transactionId>/manifest.json` with state `Preparing`.
+- `SaveChanges()` inside an active transaction appends staged operations to
+  `__cloudstorageorm/tx/<transactionId>/manifest.json` with state `Preparing`.
 - `Commit()` marks the manifest as `Committed`, replays operations in sequence, and then marks it as `Completed`.
 - `Rollback()` (or disposing an uncommitted transaction) marks the manifest as `Aborted`.
-- Recovery scans `__cloudstorageorm/tx/` when a new transaction manager starts: committed manifests are replayed/finalized; preparing manifests are aborted.
+- Recovery scans `__cloudstorageorm/tx/` when a new transaction manager starts: committed manifests are
+  replayed/finalized; preparing manifests are aborted.
+
+ETag concurrency behavior on the current branch (when explicitly enabled per entity):
+
+- entity materialization reads provider metadata ETags and stores them as original values for concurrency checks
+- updates/deletes use provider-native conditional requests (`If-Match`) against the original ETag
+- mismatches are translated to `DbUpdateConcurrencyException`
+- ETags are sourced from object storage metadata and are not persisted inside entity JSON payloads
 
 The recent query work on `main` focuses on:
 
@@ -127,7 +148,8 @@ The recent query work on `main` focuses on:
 ### Planned, not implemented yet
 
 - Google Cloud Storage provider
-- provider-native temporary locking and richer concurrency strategies (for example, Azure blob lease coordination and AWS conditional/object-lock patterns)
+- provider-native temporary locking and richer concurrency strategies (for example, Azure blob lease coordination and
+  AWS conditional/object-lock patterns)
 - broader snapshot/versioning support
 
 ---
@@ -144,8 +166,10 @@ These items are important for anyone consuming the current `main` branch:
    In particular, `CloudStorageDatabaseCreator` is still intentionally minimal and some methods remain placeholders or
    throw `NotImplementedException`.
 
-   Transactions are implemented through a provider-level journal and replay mechanism; this is still not a full relational ACID engine or a distributed lock/consensus coordinator.
-   Provider-native temporary locking is planned for future versions but is not part of the current transaction guarantee.
+   Transactions are implemented through a provider-level journal and replay mechanism; this is still not a full
+   relational ACID engine or a distributed lock/consensus coordinator.
+   Provider-native temporary locking is planned for future versions but is not part of the current transaction
+   guarantee.
 
 3. **Current branch targets .NET 10**  
    Consumers building from source should use the .NET 10 SDK.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -76,6 +76,19 @@ The workflow also publishes test results to the GitHub Actions UI on every run.
 If you want local behavior close to CI:
 
 ```bash
+./scripts/run-local-ci-tests.sh
+```
+
+That script starts:
+
+- Azurite with `--skipApiVersionCheck`
+- LocalStack `localstack/localstack:3`
+
+and then runs restore, build, and test projects with CI-aligned AWS environment variables.
+
+If you prefer the individual commands, use:
+
+```bash
 dotnet restore CloudStorageORM.sln
 dotnet build CloudStorageORM.sln --no-restore --configuration Release --verbosity normal
 

--- a/docs/testing-with-azurite.md
+++ b/docs/testing-with-azurite.md
@@ -26,8 +26,11 @@ docker run -d \
   -p 10001:10001 \
   -p 10002:10002 \
   --name azurite \
-  mcr.microsoft.com/azure-storage/azurite
+  mcr.microsoft.com/azure-storage/azurite:latest \
+  azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 ```
+
+`--skipApiVersionCheck` keeps local emulator runs compatible when SDK defaults move to newer service API versions.
 
 The repository uses the standard development connection string:
 
@@ -50,6 +53,12 @@ You should see a container named `azurite` exposing ports `10000-10002`.
 ## Run the full test suite
 
 From the repository root:
+
+```bash
+./scripts/run-local-ci-tests.sh
+```
+
+Or run tests directly:
 
 ```bash
 dotnet test CloudStorageORM.sln --nologo -v minimal
@@ -133,7 +142,8 @@ docker run -d \
   -p 10001:10001 \
   -p 10002:10002 \
   --name azurite \
-  mcr.microsoft.com/azure-storage/azurite
+  mcr.microsoft.com/azure-storage/azurite:latest \
+  azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
 ```
 
 ### Port conflicts

--- a/docs/testing-with-localstack.md
+++ b/docs/testing-with-localstack.md
@@ -24,6 +24,12 @@ docker run -d \
   localstack/localstack:3
 ```
 
+For CI-like local behavior across Azure + AWS tests, use:
+
+```bash
+./scripts/run-local-ci-tests.sh
+```
+
 ---
 
 ## Environment variables used by CloudStorageORM
@@ -33,7 +39,7 @@ These defaults are used by tests/sample if variables are not set:
 - `CLOUDSTORAGEORM_AWS_ACCESS_KEY_ID` (`test`)
 - `CLOUDSTORAGEORM_AWS_SECRET_ACCESS_KEY` (`test`)
 - `CLOUDSTORAGEORM_AWS_REGION` (`us-east-1`)
-- `CLOUDSTORAGEORM_AWS_SERVICE_URL` (`http://localhost:4566`)
+- `CLOUDSTORAGEORM_AWS_SERVICE_URL` (`http://127.0.0.1:4566`)
 - `CLOUDSTORAGEORM_AWS_BUCKET` (`cloudstorageorm-integration-tests`)
 - `CLOUDSTORAGEORM_AWS_FORCE_PATH_STYLE` (`true`)
 
@@ -87,7 +93,7 @@ Set explicit variables before running tests/sample:
 export CLOUDSTORAGEORM_AWS_ACCESS_KEY_ID=test
 export CLOUDSTORAGEORM_AWS_SECRET_ACCESS_KEY=test
 export CLOUDSTORAGEORM_AWS_REGION=us-east-1
-export CLOUDSTORAGEORM_AWS_SERVICE_URL=http://localhost:4566
+export CLOUDSTORAGEORM_AWS_SERVICE_URL=http://127.0.0.1:4566
 export CLOUDSTORAGEORM_AWS_BUCKET=cloudstorageorm-integration-tests
 export CLOUDSTORAGEORM_AWS_FORCE_PATH_STYLE=true
 ```

--- a/samples/CloudStorageORM.SampleApp/DbContext/MyAppDbContext.cs
+++ b/samples/CloudStorageORM.SampleApp/DbContext/MyAppDbContext.cs
@@ -1,4 +1,5 @@
 using CloudStorageORM.Contexts;
+using CloudStorageORM.Extensions;
 using Microsoft.EntityFrameworkCore;
 using SampleApp.Models;
 
@@ -13,6 +14,9 @@ public class MyAppDbContextInMemory(DbContextOptions<MyAppDbContextInMemory> opt
     {
         modelBuilder.Entity<User>()
             .HasKey(u => u.Id);
+
+        modelBuilder.Entity<User>()
+            .UseObjectETagConcurrency();
 
         base.OnModelCreating(modelBuilder);
     }

--- a/samples/CloudStorageORM.SampleApp/Models/User.cs
+++ b/samples/CloudStorageORM.SampleApp/Models/User.cs
@@ -1,10 +1,16 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using CloudStorageORM.Abstractions;
 
 namespace SampleApp.Models;
 
-public class User
+public class User : IETag
 {
     [MaxLength(255)] public string Id { get; init; } = string.Empty;
     [MaxLength(255)] public string Name { get; set; } = string.Empty;
     [MaxLength(255)] public string Email { get; set; } = string.Empty;
+
+    [JsonIgnore]
+    // ReSharper disable once EntityFramework.ModelValidation.UnlimitedStringLength
+    public string? ETag { get; set; }
 }

--- a/samples/CloudStorageORM.SampleApp/Program.cs
+++ b/samples/CloudStorageORM.SampleApp/Program.cs
@@ -1,8 +1,11 @@
 using System.Text;
 using CloudStorageORM.Enums;
 using CloudStorageORM.Extensions;
+using CloudStorageORM.Infrastructure;
+using CloudStorageORM.Interfaces.StorageProviders;
 using CloudStorageORM.Options;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using SampleApp.DbContext;
 using SampleApp.Models;
@@ -146,6 +149,11 @@ public static class Program
         context.Add(newUser);
         await context.SaveChangesAsync();
         Console.WriteLine($"| ✅ User {newUser.Name} created (Id {newUser.Id}).");
+        var createdUser = context is MyAppDbContextCloudStorage
+            ? await ReadStoredUserAsync(context, userId)
+            : newUser;
+        Console.WriteLine(
+            $"| 🏷️ Created user payload: {createdUser?.Id} - {createdUser?.Name} ({createdUser?.Email}) | ETag: {createdUser?.ETag ?? "<null>"}");
         Console.WriteLine("|");
 
         Console.WriteLine("| 📃 Listing users...");
@@ -157,7 +165,7 @@ public static class Program
 
         Console.WriteLine("|");
         Console.WriteLine("| ✏️ Updating the user...");
-        var userToUpdate = repository.FirstOrDefault(u => u.Id == userId);
+        var userToUpdate = await FindUserByIdAsync(context, repository, userId);
         if (userToUpdate != null)
         {
             userToUpdate.Name = "John Doe Updated";
@@ -169,7 +177,7 @@ public static class Program
 
         Console.WriteLine("|");
         Console.WriteLine("| 🔎 Finding the updated user...");
-        var foundUser = repository.FirstOrDefault(u => u.Id == userId);
+        var foundUser = await FindUserByIdAsync(context, repository, userId);
         Console.WriteLine(foundUser != null
             ? $"| 🎯 Found: {foundUser.Id} - {foundUser.Name} ({foundUser.Email})"
             : "| ❌ User not found.");
@@ -210,7 +218,8 @@ public static class Program
         Console.WriteLine($"🏁 SampleApp Finished for {context.GetType().Name}.");
     }
 
-    private static async Task RunTransactionScenario(Microsoft.EntityFrameworkCore.DbContext context, DbSet<User> repository)
+    private static async Task RunTransactionScenario(Microsoft.EntityFrameworkCore.DbContext context,
+        DbSet<User> repository)
     {
         const string rollbackUserId = $"{DeterministicUserId}-tx-rollback";
         const string commitUserId = $"{DeterministicUserId}-tx-commit";
@@ -231,7 +240,7 @@ public static class Program
         }
 
         context.ChangeTracker.Clear();
-        var rollbackFound = repository.FirstOrDefault(u => u.Id == rollbackUserId);
+        var rollbackFound = await FindUserByIdAsync(context, repository, rollbackUserId);
         Console.WriteLine(rollbackFound is null
             ? "| ✅ Rollback verification passed: user was not persisted."
             : "| ❌ Rollback verification failed: user is still present.");
@@ -252,7 +261,7 @@ public static class Program
         }
 
         context.ChangeTracker.Clear();
-        var commitFound = repository.FirstOrDefault(u => u.Id == commitUserId);
+        var commitFound = await FindUserByIdAsync(context, repository, commitUserId);
         Console.WriteLine(commitFound is not null
             ? "| ✅ Commit verification passed: user was persisted."
             : "| ❌ Commit verification failed: user was not found.");
@@ -307,6 +316,37 @@ public static class Program
         {
             return false;
         }
+    }
+
+    private static async Task<User?> FindUserByIdAsync(
+        Microsoft.EntityFrameworkCore.DbContext context,
+        DbSet<User> repository,
+        string userId)
+    {
+        if (context is MyAppDbContextCloudStorage)
+        {
+            var database = context.GetService<Microsoft.EntityFrameworkCore.Storage.IDatabase>();
+            if (database is CloudStorageDatabase cloudStorageDatabase)
+            {
+                return await cloudStorageDatabase.TryLoadByPrimaryKeyAsync<User>(userId, context);
+            }
+
+            var users = await repository.ToListAsync();
+            return users.FirstOrDefault(u => u.Id == userId);
+        }
+
+        return repository.FirstOrDefault(u => u.Id == userId);
+    }
+
+    private static async Task<User?> ReadStoredUserAsync(Microsoft.EntityFrameworkCore.DbContext context, string userId)
+    {
+        var storageProvider = context.GetService<IStorageProvider>();
+        var pathResolver = new BlobPathResolver(storageProvider);
+        var path = pathResolver.GetPath(typeof(User), userId);
+        var stored = await storageProvider.ReadWithMetadataAsync<User>(path);
+        stored.Value?.ETag = stored.ETag;
+
+        return stored.Value;
     }
 
     private static CloudStorageOptions BuildCloudStorageOptionsFromEnvironment(CloudProvider provider)

--- a/scripts/run-local-ci-tests.sh
+++ b/scripts/run-local-ci-tests.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+AZURITE_IMAGE="mcr.microsoft.com/azure-storage/azurite:latest"
+LOCALSTACK_IMAGE="localstack/localstack:3"
+
+cleanup() {
+  docker rm -f azurite localstack >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cleanup
+
+echo "Starting Azurite with --skipApiVersionCheck..."
+docker run -d \
+  -p 10000:10000 \
+  -p 10001:10001 \
+  -p 10002:10002 \
+  --name azurite \
+  "$AZURITE_IMAGE" \
+  azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck >/dev/null
+
+echo "Starting LocalStack (S3)..."
+docker run -d \
+  -p 4566:4566 \
+  -e SERVICES=s3 \
+  -e AWS_DEFAULT_REGION=us-east-1 \
+  --name localstack \
+  "$LOCALSTACK_IMAGE" >/dev/null
+
+sleep 8
+
+export CLOUDSTORAGEORM_AWS_SERVICE_URL=http://127.0.0.1:4566
+export CLOUDSTORAGEORM_AWS_ACCESS_KEY_ID=test
+export CLOUDSTORAGEORM_AWS_SECRET_ACCESS_KEY=test
+export CLOUDSTORAGEORM_AWS_REGION=us-east-1
+export CLOUDSTORAGEORM_AWS_BUCKET=cloudstorageorm-integration-tests
+
+mkdir -p TestResults/Coverage
+
+echo "Restoring solution..."
+dotnet restore CloudStorageORM.sln
+
+echo "Building solution (Release)..."
+dotnet build CloudStorageORM.sln --no-restore --configuration Release --verbosity normal
+
+declare -a projects=()
+while IFS= read -r project; do
+  projects+=("$project")
+done < <(find . -type f -iname "*.Tests.csproj" | sort)
+
+# Keep local runs aligned with CI while including the integration test project if present.
+integration_project="./tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj"
+if [[ -f "$integration_project" ]]; then
+  projects+=("$integration_project")
+fi
+
+echo "Running test projects..."
+for proj in "${projects[@]}"; do
+  name="$(basename "$proj" .csproj)"
+  echo "- $name ($proj)"
+
+  dotnet test "$proj" --configuration Release \
+    --logger "trx;LogFileName=${name}.trx" \
+    --collect:"XPlat Code Coverage"
+
+  find . -name "${name}.trx" -exec cp {} TestResults/ \;
+  find . -name "coverage.cobertura.xml" -exec cp {} "TestResults/Coverage/${name}.xml" \;
+done
+
+echo "Done. TRX files are in TestResults/ and coverage XML files are in TestResults/Coverage/."

--- a/src/CloudStorageORM/Abstractions/IETag.cs
+++ b/src/CloudStorageORM/Abstractions/IETag.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CloudStorageORM.Abstractions;
+
+public interface IETag
+{
+    [MaxLength(64)]
+    string? ETag { get; set; }
+}

--- a/src/CloudStorageORM/Abstractions/StorageObject.cs
+++ b/src/CloudStorageORM/Abstractions/StorageObject.cs
@@ -1,0 +1,3 @@
+namespace CloudStorageORM.Abstractions;
+
+public readonly record struct StorageObject<T>(T? Value, string? ETag, bool Exists);

--- a/src/CloudStorageORM/CloudStorageORM.csproj
+++ b/src/CloudStorageORM/CloudStorageORM.csproj
@@ -16,8 +16,8 @@
         <RepositoryUrl>https://github.com/rzavalik/CloudStorageORM</RepositoryUrl>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/rzavalik/CloudStorageORM</PackageProjectUrl>
-        <Description>Entity Framework integration over cloud storage providers like Azure, AWS, and Google. Lightweight ORM for cloud-native applications.</Description>
-        <PackageTags>entity-framework, orm, cloud-storage, azure, aws, google-cloud, dotnet</PackageTags>
+        <Description>Entity Framework-style integration over cloud object storage with implemented providers for Azure Blob Storage and AWS S3; Google Cloud Storage is planned.</Description>
+        <PackageTags>entity-framework, orm, cloud-storage, azure, aws, s3, blob-storage, dotnet</PackageTags>
         <LangVersion>14</LangVersion>
     </PropertyGroup>
 

--- a/src/CloudStorageORM/Constants/AnnotationsConstants.cs
+++ b/src/CloudStorageORM/Constants/AnnotationsConstants.cs
@@ -3,4 +3,6 @@ namespace CloudStorageORM.Constants;
 internal static class AnnotationsConstants
 {
     public const string BlobNameAnnotation = "CloudStorageORM:BlobName";
+    public const string ETagConcurrencyEnabledAnnotation = "CloudStorageORM:ETagConcurrencyEnabled";
+    public const string ETagConcurrencyPropertyNameAnnotation = "CloudStorageORM:ETagConcurrencyPropertyName";
 }

--- a/src/CloudStorageORM/Extensions/ModelBuilderExtensions.cs
+++ b/src/CloudStorageORM/Extensions/ModelBuilderExtensions.cs
@@ -1,14 +1,57 @@
+using System.Linq.Expressions;
 using CloudStorageORM.Abstractions;
 using CloudStorageORM.Constants;
 using CloudStorageORM.Interfaces.StorageProviders;
 using CloudStorageORM.Validators;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace CloudStorageORM.Extensions;
 
 public static class ModelBuilderExtensions
 {
+    extension(EntityTypeBuilder entityTypeBuilder)
+    {
+        public EntityTypeBuilder UseObjectETagConcurrency()
+        {
+            ArgumentNullException.ThrowIfNull(entityTypeBuilder);
+
+            entityTypeBuilder.Property<string?>("ETag").IsConcurrencyToken();
+            entityTypeBuilder.Metadata.SetAnnotation(AnnotationsConstants.ETagConcurrencyEnabledAnnotation, true);
+            entityTypeBuilder.Metadata.SetAnnotation(AnnotationsConstants.ETagConcurrencyPropertyNameAnnotation, "ETag");
+
+            return entityTypeBuilder;
+        }
+    }
+
+    public static EntityTypeBuilder<TEntity> UseObjectETagConcurrency<TEntity>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(entityTypeBuilder);
+        UseObjectETagConcurrency((EntityTypeBuilder)entityTypeBuilder);
+        return entityTypeBuilder;
+    }
+
+    public static EntityTypeBuilder<TEntity> UseObjectETagConcurrency<TEntity>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        Expression<Func<TEntity, string?>> etagPropertyExpression)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(entityTypeBuilder);
+        ArgumentNullException.ThrowIfNull(etagPropertyExpression);
+
+        var propertyBuilder = entityTypeBuilder.Property(etagPropertyExpression).IsConcurrencyToken();
+
+        entityTypeBuilder.Metadata.SetAnnotation(AnnotationsConstants.ETagConcurrencyEnabledAnnotation, true);
+        entityTypeBuilder.Metadata.SetAnnotation(
+            AnnotationsConstants.ETagConcurrencyPropertyNameAnnotation,
+            propertyBuilder.Metadata.Name);
+
+        return entityTypeBuilder;
+    }
+
     public static ModelBuilder ApplyBlobSettingsConventions(this ModelBuilder modelBuilder)
     {
         foreach (var entity in modelBuilder.Model.GetEntityTypes())
@@ -29,8 +72,8 @@ public static class ModelBuilderExtensions
     {
         var clrType = entity.ClrType;
         var blobAttr = clrType.GetCustomAttributes(typeof(BlobSettingsAttribute), false)
-                              .Cast<BlobSettingsAttribute>()
-                              .FirstOrDefault();
+            .Cast<BlobSettingsAttribute>()
+            .FirstOrDefault();
 
         var blobName = (blobAttr != null)
             ? blobAttr.Name

--- a/src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
 using System.Linq.Expressions;
+using CloudStorageORM.Abstractions;
+using CloudStorageORM.Constants;
 using CloudStorageORM.Interfaces.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
 using Microsoft.EntityFrameworkCore;
@@ -110,22 +112,54 @@ public class CloudStorageDatabase(
             switch (entry.EntityState)
             {
                 case EntityState.Added:
-                case EntityState.Modified:
-                    await ExecuteOrStageSaveAsync(path, entity, cancellationToken);
+                {
+                    var concurrencyEnabled = TryGetConcurrencyProperty(entry.EntityType, out _);
+                    var newETag = await ExecuteOrStageSaveAsync(path, entity, null, concurrencyEnabled, cancellationToken);
+                    ApplySavedETag(entry, newETag);
                     changes++;
                     break;
+                }
+
+                case EntityState.Modified:
+                {
+                    var concurrencyEnabled = TryGetConcurrencyProperty(entry.EntityType, out _);
+                    var originalETag = GetOriginalETag(entry);
+                    if (concurrencyEnabled && string.IsNullOrWhiteSpace(originalETag))
+                    {
+                        throw new DbUpdateConcurrencyException(
+                            "ETag concurrency is enabled, but no original ETag value is available for update.");
+                    }
+
+                    var newETag = await ExecuteOrStageSaveAsync(path, entity, originalETag, concurrencyEnabled,
+                        cancellationToken);
+                    ApplySavedETag(entry, newETag);
+                    changes++;
+                    break;
+                }
 
                 case EntityState.Deleted:
-                    await ExecuteOrStageDeleteAsync(path, cancellationToken);
+                {
+                    var concurrencyEnabled = TryGetConcurrencyProperty(entry.EntityType, out _);
+                    var originalETag = GetOriginalETag(entry);
+                    if (concurrencyEnabled && string.IsNullOrWhiteSpace(originalETag))
+                    {
+                        throw new DbUpdateConcurrencyException(
+                            "ETag concurrency is enabled, but no original ETag value is available for delete.");
+                    }
+
+                    await ExecuteOrStageDeleteAsync(path, originalETag, concurrencyEnabled, cancellationToken);
                     changes++;
                     break;
+                }
             }
         }
 
         return changes;
     }
 
-    private async Task ExecuteOrStageSaveAsync(string path, object entity, CancellationToken cancellationToken)
+    private async Task<string?> ExecuteOrStageSaveAsync(string path, object entity, string? ifMatchETag,
+        bool useConditionalRequest,
+        CancellationToken cancellationToken)
     {
         if (_transactionManager is CloudStorageTransactionManager { HasActiveTransaction: true } manager)
         {
@@ -138,13 +172,27 @@ public class CloudStorageDatabase(
                 manager.EnqueueOperation(_ => _storageProvider.SaveAsync(path, entity));
             }
 
-            return;
+            return null;
         }
 
-        await _storageProvider.SaveAsync(path, entity);
+        try
+        {
+            if (!useConditionalRequest)
+            {
+                await _storageProvider.SaveAsync(path, entity);
+                return null;
+            }
+
+            return await _storageProvider.SaveAsync(path, entity, ifMatchETag);
+        }
+        catch (StoragePreconditionFailedException ex)
+        {
+            throw CreateConcurrencyException(path, ex);
+        }
     }
 
-    private async Task ExecuteOrStageDeleteAsync(string path, CancellationToken cancellationToken)
+    private async Task ExecuteOrStageDeleteAsync(string path, string? ifMatchETag, bool useConditionalRequest,
+        CancellationToken cancellationToken)
     {
         if (_transactionManager is CloudStorageTransactionManager { HasActiveTransaction: true } manager)
         {
@@ -160,7 +208,20 @@ public class CloudStorageDatabase(
             return;
         }
 
-        await _storageProvider.DeleteAsync(path);
+        try
+        {
+            if (!useConditionalRequest)
+            {
+                await _storageProvider.DeleteAsync(path);
+                return;
+            }
+
+            await _storageProvider.DeleteAsync(path, ifMatchETag);
+        }
+        catch (StoragePreconditionFailedException ex)
+        {
+            throw CreateConcurrencyException(path, ex);
+        }
     }
 
     private static bool KeysMatch(EntityEntry trackedEntry, IUpdateEntry newEntry)
@@ -205,8 +266,14 @@ public class CloudStorageDatabase(
 
     private static Expression ReplaceQueryParameters(Expression query, QueryContext? queryContext)
     {
-        var parameterValues = queryContext?.ParameterValues ?? new Dictionary<string, object?>();
+        var parameterValues = TryGetQueryParameterValues(queryContext) ?? new Dictionary<string, object?>();
         return new QueryParameterReplacingVisitor(parameterValues).Visit(query);
+    }
+
+    private static IReadOnlyDictionary<string, object?>? TryGetQueryParameterValues(QueryContext? queryContext)
+    {
+        var property = queryContext?.GetType().GetProperty("ParameterValues");
+        return property?.GetValue(queryContext) as IReadOnlyDictionary<string, object?>;
     }
 
     private static bool IsSequenceResult(Type resultType)
@@ -253,11 +320,15 @@ public class CloudStorageDatabase(
 
         foreach (var file in files)
         {
-            var entity = await _storageProvider.ReadAsync<TEntity>(file);
+            var storageObject = await _storageProvider.ReadWithMetadataAsync<TEntity>(file);
+            if (!storageObject.Exists || storageObject.Value is null)
+            {
+                continue;
+            }
 
-            AttachOrReplaceTrackedEntity(context, entity);
+            AttachOrReplaceTrackedEntity(context, storageObject.Value, storageObject.ETag);
 
-            results.Add(entity);
+            results.Add(storageObject.Value);
         }
 
         return results;
@@ -275,9 +346,10 @@ public class CloudStorageDatabase(
         where TEntity : class
     {
         var path = _blobPathResolver.GetPath(typeof(TEntity), keyValue);
-        var entity = await _storageProvider.ReadAsync<TEntity>(path);
+        var storageObject = await _storageProvider.ReadWithMetadataAsync<TEntity>(path);
+        var entity = storageObject.Value;
 
-        AttachOrReplaceTrackedEntity(context ?? _context, entity);
+        AttachOrReplaceTrackedEntity(context ?? _context, entity, storageObject.ETag);
         return entity;
     }
 
@@ -317,14 +389,14 @@ public class CloudStorageDatabase(
                 continue;
             }
 
-            var entity = await _storageProvider.ReadAsync<TEntity?>(file);
-            if (entity is null)
+            var storageObject = await _storageProvider.ReadWithMetadataAsync<TEntity?>(file);
+            if (!storageObject.Exists || storageObject.Value is null)
             {
                 continue;
             }
 
-            AttachOrReplaceTrackedEntity(targetContext, entity, keyProperties);
-            results.Add(entity);
+            AttachOrReplaceTrackedEntity(targetContext, storageObject.Value, storageObject.ETag, keyProperties);
+            results.Add(storageObject.Value);
         }
 
         return results;
@@ -341,16 +413,16 @@ public class CloudStorageDatabase(
 
         foreach (var file in files)
         {
-            var entity = await _storageProvider.ReadAsync<TEntity?>(file);
+            var storageObject = await _storageProvider.ReadWithMetadataAsync<TEntity?>(file);
 
-            if (entity is null)
+            if (!storageObject.Exists || storageObject.Value is null)
             {
                 continue;
             }
 
-            AttachOrReplaceTrackedEntity(_context, entity, keyProperties);
+            AttachOrReplaceTrackedEntity(_context, storageObject.Value, storageObject.ETag, keyProperties);
 
-            results.Add(entity);
+            results.Add(storageObject.Value);
         }
 
         return results;
@@ -362,7 +434,12 @@ public class CloudStorageDatabase(
         throw new NotImplementedException();
     }
 
-    private void AttachOrReplaceTrackedEntity<TEntity>(DbContext? context, TEntity? entity,
+    public Expression<Func<QueryContext, TResult>> CompileQueryExpression<TResult>(Expression query, bool async)
+    {
+        throw new NotImplementedException();
+    }
+
+    private void AttachOrReplaceTrackedEntity<TEntity>(DbContext? context, TEntity? entity, string? eTag,
         IReadOnlyList<IProperty>? keyProperties = null)
         where TEntity : class
     {
@@ -386,6 +463,90 @@ public class CloudStorageDatabase(
         }
 
         context.Attach(entity);
+        ApplyTrackedETag(context, entity, eTag);
+    }
+
+    private static string? GetOriginalETag(IUpdateEntry entry)
+    {
+        if (!TryGetConcurrencyProperty(entry.EntityType, out var property))
+        {
+            return null;
+        }
+
+        var internalEntry = (InternalEntityEntry)entry;
+        var originalValue = internalEntry.GetOriginalValue(property!);
+        return originalValue?.ToString();
+    }
+
+    private static void ApplySavedETag(IUpdateEntry entry, string? eTag)
+    {
+        if (string.IsNullOrWhiteSpace(eTag) || !TryGetConcurrencyProperty(entry.EntityType, out var property))
+        {
+            return;
+        }
+
+        var entity = ((InternalEntityEntry)entry).Entity;
+        var dbEntry = entry.Context.Entry(entity);
+        var propertyEntry = dbEntry.Property(property!.Name);
+        propertyEntry.CurrentValue = eTag;
+        propertyEntry.OriginalValue = eTag;
+        propertyEntry.IsModified = false;
+
+        if (entity is IETag eTagEntity)
+        {
+            eTagEntity.ETag = eTag;
+        }
+    }
+
+    private static void ApplyTrackedETag<TEntity>(DbContext context, TEntity entity, string? eTag)
+        where TEntity : class
+    {
+        if (!TryGetConcurrencyProperty(context.Model.FindEntityType(typeof(TEntity)), out var property))
+        {
+            return;
+        }
+
+        var propertyEntry = context.Entry(entity).Property(property!.Name);
+        propertyEntry.CurrentValue = eTag;
+        propertyEntry.OriginalValue = eTag;
+        propertyEntry.IsModified = false;
+
+        if (entity is IETag eTagEntity)
+        {
+            eTagEntity.ETag = eTag;
+        }
+    }
+
+    private static bool TryGetConcurrencyProperty(IReadOnlyTypeBase? entityType, out IProperty? property)
+    {
+        property = null!;
+        if (entityType is not IReadOnlyEntityType readOnlyEntityType)
+        {
+            return false;
+        }
+
+        var enabled = readOnlyEntityType.FindAnnotation(AnnotationsConstants.ETagConcurrencyEnabledAnnotation)?.Value as bool?;
+        if (enabled != true)
+        {
+            return false;
+        }
+
+        var propertyName = readOnlyEntityType.FindAnnotation(AnnotationsConstants.ETagConcurrencyPropertyNameAnnotation)
+            ?.Value as string;
+        if (string.IsNullOrWhiteSpace(propertyName))
+        {
+            return false;
+        }
+
+        property = (IProperty?)readOnlyEntityType.FindProperty(propertyName);
+        return property is not null;
+    }
+
+    private static DbUpdateConcurrencyException CreateConcurrencyException(string path, Exception innerException)
+    {
+        return new DbUpdateConcurrencyException(
+            $"The operation expected the object ETag to match for '{path}', but it was updated by another process.",
+            innerException);
     }
 
     private static object ConvertToKeyType(object value, Type keyType)
@@ -423,7 +584,7 @@ public class CloudStorageDatabase(
         }
         catch
         {
-            parsed = default!;
+            parsed = null!;
             return false;
         }
     }
@@ -440,7 +601,11 @@ public class CloudStorageDatabase(
             }
         }
 
-        if (upperBound is not null)
+        if (upperBound is null)
+        {
+            return true;
+        }
+
         {
             var cmp = CompareKeyValues(keyValue, upperBound);
             if (upperInclusive ? cmp > 0 : cmp >= 0)
@@ -454,11 +619,8 @@ public class CloudStorageDatabase(
 
     private static int CompareKeyValues(object left, object right)
     {
-        if (left is not IComparable comparable)
-        {
-            throw new InvalidOperationException("Primary key type must implement IComparable for range filtering.");
-        }
-
-        return comparable.CompareTo(right);
+        return left is not IComparable comparable 
+            ? throw new InvalidOperationException("Primary key type must implement IComparable for range filtering.") 
+            : comparable.CompareTo(right);
     }
 }

--- a/src/CloudStorageORM/Infrastructure/CloudStorageQueryProvider.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageQueryProvider.cs
@@ -110,7 +110,7 @@ public class CloudStorageQueryProvider(
         // For sequence-returning expressions (Where, OrderBy, etc.) use CreateQuery so
         // the EnumerableQuery provider doesn't try to box an IQueryable<T> into a TResult.
         var resultType = typeof(TResult);
-        if (IsEnumerableResult(resultType))
+        if (IsEnumerableResult(resultType) || resultType == typeof(object) && typeof(IEnumerable<TEntity>).IsAssignableFrom(rewrittenExpression.Type))
         {
             var resultQueryable = inMemoryQueryable.Provider.CreateQuery<TEntity>(rewrittenExpression);
             return (TResult)resultQueryable;

--- a/src/CloudStorageORM/Infrastructure/CloudStorageQueryProvider.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageQueryProvider.cs
@@ -76,23 +76,23 @@ public class CloudStorageQueryProvider(
             switch (keyConstraint)
             {
                 case { IsEquality: true, EqualityValue: not null }:
-                    {
-                        var entity = await _database.TryLoadByPrimaryKeyAsync<TEntity>(keyConstraint.EqualityValue)
-                            .ConfigureAwait(false);
-                        return ConvertSingleLookupResult<TResult, TEntity>(entity);
-                    }
+                {
+                    var entity = await _database.TryLoadByPrimaryKeyAsync<TEntity>(keyConstraint.EqualityValue)
+                        .ConfigureAwait(false);
+                    return ConvertSingleLookupResult<TResult, TEntity>(entity);
+                }
                 case { IsEquality: false, HasRangeBound: true }:
-                    {
-                        var rangedList = await _database
-                            .LoadByPrimaryKeyRangeAsync<TEntity>(
-                                keyConstraint.LowerBound,
-                                keyConstraint.LowerInclusive,
-                                keyConstraint.UpperBound,
-                                keyConstraint.UpperInclusive)
-                            .ConfigureAwait(false);
+                {
+                    var rangedList = await _database
+                        .LoadByPrimaryKeyRangeAsync<TEntity>(
+                            keyConstraint.LowerBound,
+                            keyConstraint.LowerInclusive,
+                            keyConstraint.UpperBound,
+                            keyConstraint.UpperInclusive)
+                        .ConfigureAwait(false);
 
-                        return ExecuteAgainstInMemory<TResult, TEntity>(expression, rangedList);
-                    }
+                    return ExecuteAgainstInMemory<TResult, TEntity>(expression, rangedList);
+                }
             }
         }
 
@@ -105,6 +105,7 @@ public class CloudStorageQueryProvider(
     {
         var inMemoryQueryable = list.AsQueryable();
         var rewrittenExpression = new QueryRootReplacementVisitor(this, inMemoryQueryable).Visit(expression);
+        rewrittenExpression = new ExtensionReducingVisitor().Visit(rewrittenExpression);
 
         // For sequence-returning expressions (Where, OrderBy, etc.) use CreateQuery so
         // the EnumerableQuery provider doesn't try to box an IQueryable<T> into a TResult.
@@ -115,13 +116,148 @@ public class CloudStorageQueryProvider(
             return (TResult)resultQueryable;
         }
 
+        if (TryExecuteScalarFallback<TResult, TEntity>(expression, list, out var scalarFallback))
+        {
+            return scalarFallback;
+        }
+
         // For scalar/singleton results (First, Any, Count, …) invoke the generic Execute.
         var executeGeneric = typeof(IQueryProvider)
             .GetMethods(BindingFlags.Public | BindingFlags.Instance)
             .First(m => m is { Name: nameof(IQueryProvider.Execute), IsGenericMethod: true })
             .MakeGenericMethod(resultType);
 
-        return (TResult)executeGeneric.Invoke(inMemoryQueryable.Provider, [rewrittenExpression])!;
+        try
+        {
+            return (TResult)executeGeneric.Invoke(inMemoryQueryable.Provider, [rewrittenExpression])!;
+        }
+        catch (TargetInvocationException ex)
+            when (ex.InnerException is ArgumentException { Message: var message }
+                  && message.Contains("must be reducible node", StringComparison.OrdinalIgnoreCase)
+                  && TryExecuteScalarFallback<TResult, TEntity>(expression, list, out var fallback))
+        {
+            return fallback;
+        }
+    }
+
+    private static bool TryExecuteScalarFallback<TResult, TEntity>(Expression expression, IList<TEntity> list,
+        out TResult result)
+        where TEntity : class
+    {
+        result = default!;
+
+        if (expression is not MethodCallExpression methodCall
+            || methodCall.Method.DeclaringType != typeof(Queryable)
+            || !TryEvaluateSourceSequence(methodCall.Arguments[0], list, out var source))
+        {
+            return false;
+        }
+
+        Func<TEntity, bool>? predicate = null;
+        if (methodCall.Arguments.Count > 1)
+        {
+            var predicateLambda = ResolveLambda(methodCall.Arguments[1]);
+            if (predicateLambda is null)
+            {
+                return false;
+            }
+
+            predicate = (Func<TEntity, bool>)predicateLambda.Compile();
+        }
+
+        object? scalar = methodCall.Method.Name switch
+        {
+            nameof(Queryable.FirstOrDefault) => predicate is null
+                ? source.FirstOrDefault()
+                : source.FirstOrDefault(predicate),
+            nameof(Queryable.First) => predicate is null
+                ? source.First()
+                : source.First(predicate),
+            nameof(Queryable.SingleOrDefault) => predicate is null
+                ? source.SingleOrDefault()
+                : source.SingleOrDefault(predicate),
+            nameof(Queryable.Single) => predicate is null
+                ? source.Single()
+                : source.Single(predicate),
+            nameof(Queryable.Any) => predicate is null
+                ? source.Any()
+                : source.Any(predicate),
+            nameof(Queryable.Count) => predicate is null
+                ? source.Count()
+                : source.Count(predicate),
+            nameof(Queryable.LongCount) => predicate is null
+                ? source.LongCount()
+                : source.LongCount(predicate),
+            _ => null
+        };
+
+        if (scalar is null && typeof(TResult).IsValueType && Nullable.GetUnderlyingType(typeof(TResult)) is null)
+        {
+            return false;
+        }
+
+        result = (TResult)scalar!;
+        return true;
+    }
+
+    private static bool TryEvaluateSourceSequence<TEntity>(Expression expression, IList<TEntity> root,
+        out IEnumerable<TEntity> sequence)
+        where TEntity : class
+    {
+        sequence = root;
+
+        if (expression is not MethodCallExpression methodCall
+            || methodCall.Method.DeclaringType != typeof(Queryable)
+            || methodCall.Method.Name != nameof(Queryable.Where)
+            || methodCall.Arguments.Count != 2)
+        {
+            return true;
+        }
+
+        if (!TryEvaluateSourceSequence(methodCall.Arguments[0], root, out var source))
+        {
+            return false;
+        }
+
+        var predicateLambda = ResolveLambda(methodCall.Arguments[1]);
+        if (predicateLambda is null)
+        {
+            return false;
+        }
+
+        var predicate = (Func<TEntity, bool>)predicateLambda.Compile();
+        sequence = source.Where(predicate);
+        return true;
+    }
+
+    private static LambdaExpression? ResolveLambda(Expression expression)
+    {
+        var direct = UnwrapLambda(expression);
+        if (direct is not null)
+        {
+            return direct;
+        }
+
+        if (expression is ConstantExpression { Value: LambdaExpression constantLambda })
+        {
+            return constantLambda;
+        }
+
+        if (expression.CanReduce)
+        {
+            return ResolveLambda(expression.Reduce());
+        }
+
+        try
+        {
+            var boxed = Expression.Convert(expression, typeof(object));
+            var value = Expression.Lambda<Func<object?>>(boxed).Compile().Invoke();
+            return value as LambdaExpression;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static Type ResolveEntityType(Expression expression, Type resultType)
@@ -528,6 +664,16 @@ public class CloudStorageQueryProvider(
             }
 
             return base.VisitConstant(node);
+        }
+    }
+
+    private sealed class ExtensionReducingVisitor : ExpressionVisitor
+    {
+        protected override Expression VisitExtension(Expression node)
+        {
+            return node.CanReduce
+                ? Visit(node.Reduce())
+                : base.VisitExtension(node);
         }
     }
 

--- a/src/CloudStorageORM/Infrastructure/StoragePreconditionFailedException.cs
+++ b/src/CloudStorageORM/Infrastructure/StoragePreconditionFailedException.cs
@@ -1,0 +1,7 @@
+namespace CloudStorageORM.Infrastructure;
+
+internal sealed class StoragePreconditionFailedException(string path, Exception? innerException = null)
+    : Exception($"The object at path '{path}' was changed by another writer.", innerException)
+{
+    public string Path { get; } = path;
+}

--- a/src/CloudStorageORM/Interfaces/StorageProviders/IStorageProvider.cs
+++ b/src/CloudStorageORM/Interfaces/StorageProviders/IStorageProvider.cs
@@ -1,3 +1,4 @@
+using CloudStorageORM.Abstractions;
 using CloudStorageORM.Enums;
 
 namespace CloudStorageORM.Interfaces.StorageProviders;
@@ -8,8 +9,11 @@ public interface IStorageProvider
     Task DeleteContainerAsync();
     Task CreateContainerIfNotExistsAsync();
     Task SaveAsync<T>(string path, T entity);
+    Task<string?> SaveAsync<T>(string path, T entity, string? ifMatchETag);
     Task<T> ReadAsync<T>(string path);
+    Task<StorageObject<T>> ReadWithMetadataAsync<T>(string path);
     Task DeleteAsync(string path);
+    Task DeleteAsync(string path, string? ifMatchETag);
     Task<List<string>> ListAsync(string folderPath);
     string SanitizeBlobName(string rawName);
 }

--- a/src/CloudStorageORM/Providers/Aws/StorageProviders/AwsS3StorageProvider.cs
+++ b/src/CloudStorageORM/Providers/Aws/StorageProviders/AwsS3StorageProvider.cs
@@ -108,6 +108,15 @@ public class AwsS3StorageProvider : IStorageProvider
 
         try
         {
+            if (!string.IsNullOrWhiteSpace(ifMatchETag))
+            {
+                var currentEtag = await GetObjectETagAsync(path);
+                if (!ETagMatches(currentEtag, ifMatchETag))
+                {
+                    throw new StoragePreconditionFailedException(path);
+                }
+            }
+
             var response = await _s3Client.PutObjectAsync(new PutObjectRequest
             {
                 BucketName = _bucketName,
@@ -117,18 +126,12 @@ public class AwsS3StorageProvider : IStorageProvider
                 IfMatch = string.IsNullOrWhiteSpace(ifMatchETag) ? null : ifMatchETag
             });
 
-            if (!string.IsNullOrWhiteSpace(response.ETag))
+            if (!string.IsNullOrWhiteSpace(response?.ETag))
             {
                 return response.ETag;
             }
 
-            var metadata = await _s3Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
-            {
-                BucketName = _bucketName,
-                Key = path
-            });
-
-            return metadata.ETag;
+            return await GetObjectETagAsync(path);
         }
         catch (AmazonS3Exception ex) when (IsPreconditionFailed(ex))
         {
@@ -162,13 +165,7 @@ public class AwsS3StorageProvider : IStorageProvider
                 return new StorageObject<T>(JsonSerializer.Deserialize<T>(json), etag, true);
             }
 
-            var metadata = await _s3Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
-            {
-                BucketName = _bucketName,
-                Key = path
-            });
-
-            etag = metadata.ETag;
+            etag = await GetObjectETagAsync(path);
 
             return new StorageObject<T>(JsonSerializer.Deserialize<T>(json), etag, true);
         }
@@ -270,5 +267,34 @@ public class AwsS3StorageProvider : IStorageProvider
     {
         return ex.StatusCode == HttpStatusCode.PreconditionFailed
                || string.Equals(ex.ErrorCode, "PreconditionFailed", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<string?> GetObjectETagAsync(string path)
+    {
+        var metadataTask = _s3Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+        {
+            BucketName = _bucketName,
+            Key = path
+        });
+
+        if (metadataTask is null)
+        {
+            return null;
+        }
+
+        var metadata = await metadataTask;
+        return metadata?.ETag;
+    }
+
+    private static bool ETagMatches(string? currentETag, string expectedETag)
+    {
+        if (string.IsNullOrWhiteSpace(currentETag) || string.IsNullOrWhiteSpace(expectedETag))
+        {
+            return false;
+        }
+
+        var normalizedCurrent = currentETag.Trim().Trim('"');
+        var normalizedExpected = expectedETag.Trim().Trim('"');
+        return string.Equals(normalizedCurrent, normalizedExpected, StringComparison.Ordinal);
     }
 }

--- a/src/CloudStorageORM/Providers/Aws/StorageProviders/AwsS3StorageProvider.cs
+++ b/src/CloudStorageORM/Providers/Aws/StorageProviders/AwsS3StorageProvider.cs
@@ -6,7 +6,9 @@ using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
+using CloudStorageORM.Abstractions;
 using CloudStorageORM.Enums;
+using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
 using CloudStorageORM.Options;
 
@@ -95,20 +97,52 @@ public class AwsS3StorageProvider : IStorageProvider
 
     public async Task SaveAsync<T>(string path, T entity)
     {
+        await SaveAsync(path, entity, ifMatchETag: null);
+    }
+
+    public async Task<string?> SaveAsync<T>(string path, T entity, string? ifMatchETag)
+    {
         await EnsureBucketExistsAsync();
 
         var json = JsonSerializer.Serialize(entity);
 
-        await _s3Client.PutObjectAsync(new PutObjectRequest
+        try
         {
-            BucketName = _bucketName,
-            Key = path,
-            ContentBody = json,
-            ContentType = "application/json"
-        });
+            var response = await _s3Client.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = _bucketName,
+                Key = path,
+                ContentBody = json,
+                ContentType = "application/json",
+                IfMatch = string.IsNullOrWhiteSpace(ifMatchETag) ? null : ifMatchETag
+            });
+
+            if (!string.IsNullOrWhiteSpace(response.ETag))
+            {
+                return response.ETag;
+            }
+
+            var metadata = await _s3Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+            {
+                BucketName = _bucketName,
+                Key = path
+            });
+
+            return metadata.ETag;
+        }
+        catch (AmazonS3Exception ex) when (IsPreconditionFailed(ex))
+        {
+            throw new StoragePreconditionFailedException(path, ex);
+        }
     }
 
     public async Task<T> ReadAsync<T>(string path)
+    {
+        var storageObject = await ReadWithMetadataAsync<T>(path);
+        return storageObject.Value!;
+    }
+
+    public async Task<StorageObject<T>> ReadWithMetadataAsync<T>(string path)
     {
         await EnsureBucketExistsAsync();
 
@@ -122,26 +156,53 @@ public class AwsS3StorageProvider : IStorageProvider
 
             using var reader = new StreamReader(response.ResponseStream);
             var json = await reader.ReadToEndAsync();
-            return JsonSerializer.Deserialize<T>(json)!;
+            var etag = response.ETag;
+            if (!string.IsNullOrWhiteSpace(etag))
+            {
+                return new StorageObject<T>(JsonSerializer.Deserialize<T>(json), etag, true);
+            }
+
+            var metadata = await _s3Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+            {
+                BucketName = _bucketName,
+                Key = path
+            });
+
+            etag = metadata.ETag;
+
+            return new StorageObject<T>(JsonSerializer.Deserialize<T>(json), etag, true);
         }
         catch (AmazonS3Exception ex) when (
             ex.StatusCode == HttpStatusCode.NotFound ||
             string.Equals(ex.ErrorCode, "NoSuchKey", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(ex.ErrorCode, "NoSuchBucket", StringComparison.OrdinalIgnoreCase))
         {
-            return default!;
+            return new StorageObject<T>(default, null, false);
         }
     }
 
     public async Task DeleteAsync(string path)
     {
+        await DeleteAsync(path, ifMatchETag: null);
+    }
+
+    public async Task DeleteAsync(string path, string? ifMatchETag)
+    {
         await EnsureBucketExistsAsync();
 
-        await _s3Client.DeleteObjectAsync(new DeleteObjectRequest
+        try
         {
-            BucketName = _bucketName,
-            Key = path
-        });
+            await _s3Client.DeleteObjectAsync(new DeleteObjectRequest
+            {
+                BucketName = _bucketName,
+                Key = path,
+                IfMatch = string.IsNullOrWhiteSpace(ifMatchETag) ? null : ifMatchETag
+            });
+        }
+        catch (AmazonS3Exception ex) when (IsPreconditionFailed(ex))
+        {
+            throw new StoragePreconditionFailedException(path, ex);
+        }
     }
 
     public async Task<List<string>> ListAsync(string folderPath)
@@ -203,5 +264,11 @@ public class AwsS3StorageProvider : IStorageProvider
         {
             _bucketInitLock.Release();
         }
+    }
+
+    private static bool IsPreconditionFailed(AmazonS3Exception ex)
+    {
+        return ex.StatusCode == HttpStatusCode.PreconditionFailed
+               || string.Equals(ex.ErrorCode, "PreconditionFailed", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/CloudStorageORM/Providers/Azure/StorageProviders/AzureBlobStorageProvider.cs
+++ b/src/CloudStorageORM/Providers/Azure/StorageProviders/AzureBlobStorageProvider.cs
@@ -68,9 +68,12 @@ public class AzureBlobStorageProvider : IStorageProvider
             {
                 var response = await blobClient.UploadAsync(stream, overwrite: true);
                 var etag = response.Value?.ETag.ToString();
-                return !string.IsNullOrWhiteSpace(etag)
-                    ? etag
-                    : (await blobClient.GetPropertiesAsync()).Value.ETag.ToString();
+                if (!string.IsNullOrWhiteSpace(etag))
+                {
+                    return etag;
+                }
+
+                return await TryGetBlobETagAsync(blobClient);
             }
 
             var conditionalResponse = await blobClient.UploadAsync(stream, new BlobUploadOptions
@@ -82,9 +85,12 @@ public class AzureBlobStorageProvider : IStorageProvider
             });
 
             var conditionalETag = conditionalResponse.Value?.ETag.ToString();
-            return !string.IsNullOrWhiteSpace(conditionalETag)
-                ? conditionalETag
-                : (await blobClient.GetPropertiesAsync()).Value.ETag.ToString();
+            if (!string.IsNullOrWhiteSpace(conditionalETag))
+            {
+                return conditionalETag;
+            }
+
+            return await TryGetBlobETagAsync(blobClient);
         }
         catch (RequestFailedException ex) when (ex.Status == 412)
         {
@@ -107,9 +113,9 @@ public class AzureBlobStorageProvider : IStorageProvider
         }
 
         var response = await blobClient.DownloadContentAsync();
-        var properties = await blobClient.GetPropertiesAsync();
+        var etag = await TryGetBlobETagAsync(blobClient);
         var entity = JsonSerializer.Deserialize<T>(response.Value.Content.ToString());
-        return new StorageObject<T>(entity, properties.Value.ETag.ToString(), true);
+        return new StorageObject<T>(entity, etag, true);
     }
 
     public async Task DeleteAsync(string path)
@@ -183,5 +189,17 @@ public class AzureBlobStorageProvider : IStorageProvider
             // Keep emulator compatibility when SDK default service versions move forward.
             ? new BlobClientOptions(BlobClientOptions.ServiceVersion.V2021_12_02)
             : new BlobClientOptions();
+    }
+
+    private static async Task<string?> TryGetBlobETagAsync(BlobClient blobClient)
+    {
+        var propertiesTask = blobClient.GetPropertiesAsync();
+        if (propertiesTask is null)
+        {
+            return null;
+        }
+
+        var propertiesResponse = await propertiesTask;
+        return propertiesResponse?.Value?.ETag.ToString();
     }
 }

--- a/src/CloudStorageORM/Providers/Azure/StorageProviders/AzureBlobStorageProvider.cs
+++ b/src/CloudStorageORM/Providers/Azure/StorageProviders/AzureBlobStorageProvider.cs
@@ -1,7 +1,11 @@
 using System.Text;
 using System.Text.Json;
+using Azure;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using CloudStorageORM.Abstractions;
 using CloudStorageORM.Enums;
+using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
 using CloudStorageORM.Options;
 
@@ -10,12 +14,19 @@ namespace CloudStorageORM.Providers.Azure.StorageProviders;
 public class AzureBlobStorageProvider : IStorageProvider
 {
     private readonly BlobContainerClient _containerClient;
+    private const string DevelopmentStorageConnectionString = "UseDevelopmentStorage=true";
 
     private static Func<CloudStorageOptions, BlobContainerClient> OptionsContainerClientFactory { get; set; }
-        = options => new BlobContainerClient(options.Azure.ConnectionString, options.ContainerName);
+        = options => new BlobContainerClient(
+            options.Azure.ConnectionString,
+            options.ContainerName,
+            CreateBlobClientOptions(options.Azure.ConnectionString));
 
     internal static Func<string, string, BlobContainerClient> ConnectionContainerClientFactory { get; set; }
-        = (connectionString, containerName) => new BlobContainerClient(connectionString, containerName);
+        = (connectionString, containerName) => new BlobContainerClient(
+            connectionString,
+            containerName,
+            CreateBlobClientOptions(connectionString));
 
     public AzureBlobStorageProvider(
         CloudStorageOptions options)
@@ -42,34 +53,103 @@ public class AzureBlobStorageProvider : IStorageProvider
 
     public async Task SaveAsync<T>(string path, T entity)
     {
+        await SaveAsync(path, entity, ifMatchETag: null);
+    }
+
+    public async Task<string?> SaveAsync<T>(string path, T entity, string? ifMatchETag)
+    {
         var blobClient = _containerClient.GetBlobClient(path);
         var json = JsonSerializer.Serialize(entity);
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
-        await blobClient.UploadAsync(stream, overwrite: true);
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(ifMatchETag))
+            {
+                var response = await blobClient.UploadAsync(stream, overwrite: true);
+                var etag = response.Value?.ETag.ToString();
+                return !string.IsNullOrWhiteSpace(etag)
+                    ? etag
+                    : (await blobClient.GetPropertiesAsync()).Value.ETag.ToString();
+            }
+
+            var conditionalResponse = await blobClient.UploadAsync(stream, new BlobUploadOptions
+            {
+                Conditions = new BlobRequestConditions
+                {
+                    IfMatch = new ETag(ifMatchETag)
+                }
+            });
+
+            var conditionalETag = conditionalResponse.Value?.ETag.ToString();
+            return !string.IsNullOrWhiteSpace(conditionalETag)
+                ? conditionalETag
+                : (await blobClient.GetPropertiesAsync()).Value.ETag.ToString();
+        }
+        catch (RequestFailedException ex) when (ex.Status == 412)
+        {
+            throw new StoragePreconditionFailedException(path, ex);
+        }
     }
 
     public async Task<T> ReadAsync<T>(string path)
     {
+        var storageObject = await ReadWithMetadataAsync<T>(path);
+        return storageObject.Value!;
+    }
+
+    public async Task<StorageObject<T>> ReadWithMetadataAsync<T>(string path)
+    {
         var blobClient = _containerClient.GetBlobClient(path);
         if (!await blobClient.ExistsAsync())
         {
-            return default!;
+            return new StorageObject<T>(default, null, false);
         }
 
         var response = await blobClient.DownloadContentAsync();
-        return JsonSerializer.Deserialize<T>(response.Value.Content.ToString())!;
+        var properties = await blobClient.GetPropertiesAsync();
+        var entity = JsonSerializer.Deserialize<T>(response.Value.Content.ToString());
+        return new StorageObject<T>(entity, properties.Value.ETag.ToString(), true);
     }
 
     public async Task DeleteAsync(string path)
     {
+        await DeleteAsync(path, ifMatchETag: null);
+    }
+
+    public async Task DeleteAsync(string path, string? ifMatchETag)
+    {
         var blobClient = _containerClient.GetBlobClient(path);
-        await blobClient.DeleteIfExistsAsync();
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(ifMatchETag))
+            {
+                await blobClient.DeleteIfExistsAsync();
+                return;
+            }
+
+            await blobClient.DeleteIfExistsAsync(
+                DeleteSnapshotsOption.None,
+                new BlobRequestConditions
+                {
+                    IfMatch = new ETag(ifMatchETag)
+                });
+        }
+        catch (RequestFailedException ex) when (ex.Status == 412)
+        {
+            throw new StoragePreconditionFailedException(path, ex);
+        }
     }
 
     public async Task<List<string>> ListAsync(string folderPath)
     {
         var result = new List<string>();
-        await foreach (var blobItem in _containerClient.GetBlobsAsync(prefix: folderPath))
+        await foreach (var blobItem in _containerClient.GetBlobsAsync(
+                           BlobTraits.None,
+                           BlobStates.None,
+                           folderPath,
+                           CancellationToken.None))
         {
             result.Add(blobItem.Name);
         }
@@ -95,5 +175,13 @@ public class AzureBlobStorageProvider : IStorageProvider
         }
 
         return sanitizedName.ToString().ToLowerInvariant();
+    }
+
+    private static BlobClientOptions CreateBlobClientOptions(string connectionString)
+    {
+        return string.Equals(connectionString, DevelopmentStorageConnectionString, StringComparison.OrdinalIgnoreCase)
+            // Keep emulator compatibility when SDK default service versions move forward.
+            ? new BlobClientOptions(BlobClientOptions.ServiceVersion.V2021_12_02)
+            : new BlobClientOptions();
     }
 }

--- a/tests/CloudStorageORM.IntegrationTests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
+++ b/tests/CloudStorageORM.IntegrationTests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
@@ -54,6 +54,23 @@ public class AwsS3StorageProviderTests(LocalStackFixture fixture) : IClassFixtur
         files.ShouldContain(x => x.EndsWith("list-entity2.json"));
     }
 
+    [Fact]
+    public async Task SaveAsync_WithStaleEtag_ShouldThrowStoragePreconditionFailedException()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var path = BuildPath("concurrency");
+        await fixture.Provider.SaveAsync(path, new TestEntity { Id = "etag", Name = "v1" });
+        var original = await fixture.Provider.ReadWithMetadataAsync<TestEntity>(path);
+
+        await fixture.Provider.SaveAsync(path, new TestEntity { Id = "etag", Name = "v2" });
+
+        var ex = await Should.ThrowAsync<Exception>(() =>
+            fixture.Provider.SaveAsync(path, new TestEntity { Id = "etag", Name = "v3" }, original.ETag));
+
+        ex.Message.ShouldContain("changed by another writer");
+    }
+
     private static string BuildPath(string scenario)
     {
         return $"test-folder/{scenario}-{Guid.NewGuid():N}.json";

--- a/tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj
+++ b/tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj
@@ -20,7 +20,10 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Shouldly"/>
         <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/CloudStorageORM.IntegrationTests/StorageProviders/AzureBlobStorageProvider.cs
+++ b/tests/CloudStorageORM.IntegrationTests/StorageProviders/AzureBlobStorageProvider.cs
@@ -51,6 +51,25 @@ public class AzureBlobStorageProviderTests(StorageFixture fixture) : IClassFixtu
         files.ShouldNotBeEmpty();
         files.Count.ShouldBeGreaterThanOrEqualTo(2);
     }
+
+    [Fact]
+    public async Task SaveAsync_WithStaleEtag_ShouldThrowStoragePreconditionFailedException()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var provider = new AzureBlobStorageProvider(fixture.ConnectionString, fixture.ContainerName);
+        var path = $"test-folder/concurrency-{Guid.NewGuid():N}.json";
+
+        await provider.SaveAsync(path, new TestEntity { Id = "etag", Name = "v1" });
+        var original = await provider.ReadWithMetadataAsync<TestEntity>(path);
+
+        await provider.SaveAsync(path, new TestEntity { Id = "etag", Name = "v2" });
+
+        var ex = await Should.ThrowAsync<Exception>(() =>
+            provider.SaveAsync(path, new TestEntity { Id = "etag", Name = "v3" }, original.ETag));
+
+        ex.Message.ShouldContain("changed by another writer");
+    }
 }
 
 public class TestEntity

--- a/tests/CloudStorageORM.Tests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
+++ b/tests/CloudStorageORM.Tests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
@@ -72,12 +72,29 @@ public class AwsS3StorageProviderTests
         s3Mock.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
             .Callback<PutObjectRequest, CancellationToken>((request, _) => capturedRequest = request)
             .ReturnsAsync(new PutObjectResponse());
+        s3Mock.Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetObjectMetadataResponse { ETag = "etag-1" });
 
         var sut = CreateSut(s3Mock);
         await sut.SaveAsync("users/id-1.json", new TestEntity { Id = "id-1", Name = "Alice" }, "etag-1");
 
         capturedRequest.ShouldNotBeNull();
         capturedRequest.IfMatch.ShouldBe("etag-1");
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithStaleEtag_ShouldThrowStoragePreconditionFailedException()
+    {
+        var s3Mock = new Mock<IAmazonS3>();
+        s3Mock.Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetObjectMetadataResponse { ETag = "etag-new" });
+
+        var sut = CreateSut(s3Mock);
+
+        await Should.ThrowAsync<StoragePreconditionFailedException>(() =>
+            sut.SaveAsync("users/id-1.json", new TestEntity { Id = "id-1", Name = "Alice" }, "etag-old"));
+
+        s3Mock.Verify(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/tests/CloudStorageORM.Tests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
+++ b/tests/CloudStorageORM.Tests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Amazon.S3;
 using Amazon.S3.Model;
 using CloudStorageORM.Enums;
+using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Options;
 using CloudStorageORM.Providers.Aws.StorageProviders;
 using Moq;
@@ -64,6 +65,39 @@ public class AwsS3StorageProviderTests
     }
 
     [Fact]
+    public async Task SaveAsync_WithIfMatch_ShouldSendConditionalRequest()
+    {
+        var s3Mock = new Mock<IAmazonS3>();
+        PutObjectRequest? capturedRequest = null;
+        s3Mock.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectRequest, CancellationToken>((request, _) => capturedRequest = request)
+            .ReturnsAsync(new PutObjectResponse());
+
+        var sut = CreateSut(s3Mock);
+        await sut.SaveAsync("users/id-1.json", new TestEntity { Id = "id-1", Name = "Alice" }, "etag-1");
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.IfMatch.ShouldBe("etag-1");
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithIfMatchAndPreconditionFailure_ShouldThrowStoragePreconditionFailedException()
+    {
+        var s3Mock = new Mock<IAmazonS3>();
+        s3Mock.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AmazonS3Exception("conflict")
+            {
+                StatusCode = HttpStatusCode.PreconditionFailed,
+                ErrorCode = "PreconditionFailed"
+            });
+
+        var sut = CreateSut(s3Mock);
+
+        await Should.ThrowAsync<StoragePreconditionFailedException>(() =>
+            sut.SaveAsync("users/id-1.json", new TestEntity { Id = "id-1", Name = "Alice" }, "etag-1"));
+    }
+
+    [Fact]
     public async Task ReadAsync_WhenObjectExists_ShouldReturnEntity()
     {
         var s3Mock = new Mock<IAmazonS3>();
@@ -121,6 +155,22 @@ public class AwsS3StorageProviderTests
     }
 
     [Fact]
+    public async Task DeleteAsync_WithIfMatch_ShouldSendConditionalRequest()
+    {
+        var s3Mock = new Mock<IAmazonS3>();
+        DeleteObjectRequest? capturedRequest = null;
+        s3Mock.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => capturedRequest = request)
+            .ReturnsAsync(new DeleteObjectResponse());
+
+        var sut = CreateSut(s3Mock);
+        await sut.DeleteAsync("users/id-3.json", "etag-3");
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.IfMatch.ShouldBe("etag-3");
+    }
+
+    [Fact]
     public async Task ListAsync_ShouldReturnObjectKeys()
     {
         var s3Mock = new Mock<IAmazonS3>();
@@ -154,7 +204,7 @@ public class AwsS3StorageProviderTests
 
         var sut = CreateSut(s3Mock);
 
-        await Should.NotThrowAsync(() => sut.DeleteContainerAsync());
+        await Should.NotThrowAsync(sut.DeleteContainerAsync);
     }
 
     [Fact]

--- a/tests/CloudStorageORM.Tests/Azure/StorageProviders/AzureBlobStorageProviderTests.cs
+++ b/tests/CloudStorageORM.Tests/Azure/StorageProviders/AzureBlobStorageProviderTests.cs
@@ -1,9 +1,8 @@
-using System.Reflection;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using CloudStorageORM.Enums;
-using CloudStorageORM.Options;
+using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Providers.Azure.StorageProviders;
 using Moq;
 using Shouldly;
@@ -12,26 +11,17 @@ namespace CloudStorageORM.Tests.Azure.StorageProviders;
 
 public class AzureBlobStorageProviderTests
 {
-    private AzureBlobStorageProvider MakeSut(Mock<BlobContainerClient> containerClientMock)
+    private static AzureBlobStorageProvider MakeSut(Mock<BlobContainerClient> containerClientMock)
     {
-        var options = new CloudStorageOptions
-        {
-            Provider = CloudProvider.Azure,
-            ContainerName = "test-container",
-            Azure = new CloudStorageAzureOptions
-            {
-                ConnectionString = "UseDevelopmentStorage=true"
-            }
-        };
+        containerClientMock
+            .Setup(x => x.CreateIfNotExists(
+                PublicAccessType.None,
+                null,
+                null,
+                It.IsAny<CancellationToken>()))
+            .Returns(Mock.Of<Response<BlobContainerInfo>>());
 
-        var sut = new AzureBlobStorageProvider(options);
-
-        typeof(AzureBlobStorageProvider)
-            .GetField("_containerClient",
-                BindingFlags.NonPublic | BindingFlags.Instance)!
-            .SetValue(sut, containerClientMock.Object);
-
-        return sut;
+        return new AzureBlobStorageProvider(containerClientMock.Object);
     }
 
     [Fact]
@@ -70,6 +60,53 @@ public class AzureBlobStorageProviderTests
     }
 
     [Fact]
+    public async Task SaveAsync_WithIfMatch_ShouldUseConditionalRequest()
+    {
+        var containerClientMock = new Mock<BlobContainerClient>();
+        var blobClientMock = new Mock<BlobClient>();
+
+        containerClientMock
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobClientMock.Object);
+
+        blobClientMock
+            .Setup(x => x.UploadAsync(
+                It.IsAny<Stream>(),
+                It.Is<BlobUploadOptions>(o => o.Conditions != null && o.Conditions.IfMatch.ToString() == "etag-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Mock.Of<Response<BlobContentInfo>>());
+
+        var sut = MakeSut(containerClientMock);
+
+        await sut.SaveAsync("test-folder/entity1.json", new TestEntity { Id = "entity1", Name = "Test" }, "etag-1");
+
+        blobClientMock.Verify(x => x.UploadAsync(
+            It.IsAny<Stream>(),
+            It.IsAny<BlobUploadOptions>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithIfMatchAndPreconditionFailure_ShouldThrowStoragePreconditionFailedException()
+    {
+        var containerClientMock = new Mock<BlobContainerClient>();
+        var blobClientMock = new Mock<BlobClient>();
+
+        containerClientMock
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobClientMock.Object);
+
+        blobClientMock
+            .Setup(x => x.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new RequestFailedException(412, "Precondition failed"));
+
+        var sut = MakeSut(containerClientMock);
+
+        await Should.ThrowAsync<StoragePreconditionFailedException>(() =>
+            sut.SaveAsync("test-folder/entity1.json", new TestEntity { Id = "entity1", Name = "Test" }, "etag-1"));
+    }
+
+    [Fact]
     public async Task DeleteAsync_ShouldDeleteEntity()
     {
         var containerClientMock = new Mock<BlobContainerClient>();
@@ -93,6 +130,33 @@ public class AzureBlobStorageProviderTests
         blobClientMock.Verify(x => x.DeleteIfExistsAsync(
             DeleteSnapshotsOption.None,
             null,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithIfMatch_ShouldUseConditionalRequest()
+    {
+        var containerClientMock = new Mock<BlobContainerClient>();
+        var blobClientMock = new Mock<BlobClient>();
+
+        containerClientMock
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobClientMock.Object);
+
+        blobClientMock
+            .Setup(x => x.DeleteIfExistsAsync(
+                DeleteSnapshotsOption.None,
+                It.Is<BlobRequestConditions>(c => c.IfMatch.ToString() == "etag-2"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
+
+        var sut = MakeSut(containerClientMock);
+
+        await sut.DeleteAsync("test-folder/entity2.json", "etag-2");
+
+        blobClientMock.Verify(x => x.DeleteIfExistsAsync(
+            DeleteSnapshotsOption.None,
+            It.IsAny<BlobRequestConditions>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -190,7 +254,7 @@ public class AzureBlobStorageProviderTests
                 PublicAccessType.None,
                 null,
                 null,
-                default))
+                CancellationToken.None))
             .Returns(Mock.Of<Response<BlobContainerInfo>>());
 
         var previousFactory = AzureBlobStorageProvider.ConnectionContainerClientFactory;
@@ -207,7 +271,11 @@ public class AzureBlobStorageProviderTests
 
             sut.CloudProvider.ShouldBe(CloudProvider.Azure);
             containerClientMock.Verify(
-                x => x.CreateIfNotExists(PublicAccessType.None, null, null, default),
+                x => x.CreateIfNotExists(
+                    PublicAccessType.None,
+                    null,
+                    null,
+                    CancellationToken.None),
                 Times.Once);
         }
         finally

--- a/tests/CloudStorageORM.Tests/CloudStorageORM.Tests.csproj
+++ b/tests/CloudStorageORM.Tests/CloudStorageORM.Tests.csproj
@@ -26,7 +26,10 @@
         <PackageReference Include="Moq"/>
         <PackageReference Include="Shouldly"/>
         <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"/>
     </ItemGroup>
 

--- a/tests/CloudStorageORM.Tests/Extensions/ModelBuilderExtensionsTests.cs
+++ b/tests/CloudStorageORM.Tests/Extensions/ModelBuilderExtensionsTests.cs
@@ -8,6 +8,8 @@ namespace CloudStorageORM.Tests.Extensions;
 public class ModelBuilderExtensionsTests
 {
     private const string AnnotationsConstantBlobName = "CloudStorageORM:BlobName";
+    private const string ETagConcurrencyEnabledAnnotation = "CloudStorageORM:ETagConcurrencyEnabled";
+    private const string ETagConcurrencyPropertyNameAnnotation = "CloudStorageORM:ETagConcurrencyPropertyName";
 
     [BlobSettings("__ModelA")]
     private class ModelA
@@ -25,6 +27,13 @@ public class ModelBuilderExtensionsTests
 
     private class ModelC : ModelA
     {
+    }
+
+    private class ModelWithEtag
+    {
+        public string Id { get; init; } = string.Empty;
+        // ReSharper disable once PropertyCanBeMadeInitOnly.Local
+        public string? ETag { get; set; }
     }
 
     private static ModelBuilder MakeModelBuilderWith(params Type[] types)
@@ -129,7 +138,7 @@ public class ModelBuilderExtensionsTests
         // Empty names are rejected after trimming because the resulting blob name is invalid.
         var modelBuilder = MakeModelBuilderWith(typeof(ModelWithEmptyBlobName));
 
-        var ex = Should.Throw<InvalidOperationException>(() => modelBuilder.ApplyBlobSettingsConventions());
+        var ex = Should.Throw<InvalidOperationException>(modelBuilder.ApplyBlobSettingsConventions);
 
         ex.Message.ShouldContain("has no Blob name");
     }
@@ -155,5 +164,35 @@ public class ModelBuilderExtensionsTests
         var result = modelBuilder.ApplyBlobSettingsConventions();
 
         result.ShouldBeSameAs(modelBuilder);
+    }
+
+    [Fact]
+    public void UseObjectETagConcurrency_WithoutExpression_UsesEtagShadowPropertyAndConcurrencyToken()
+    {
+        var modelBuilder = MakeModelBuilderWith(typeof(ModelB));
+
+        modelBuilder.Entity<ModelB>().UseObjectETagConcurrency();
+        var entityType = modelBuilder.Model.FindEntityType(typeof(ModelB))!;
+        var etagProperty = entityType.FindProperty("ETag");
+
+        etagProperty.ShouldNotBeNull();
+        etagProperty.IsConcurrencyToken.ShouldBeTrue();
+        entityType.FindAnnotation(ETagConcurrencyEnabledAnnotation)!.Value.ShouldBe(true);
+        entityType.FindAnnotation(ETagConcurrencyPropertyNameAnnotation)!.Value.ShouldBe("ETag");
+    }
+
+    [Fact]
+    public void UseObjectETagConcurrency_WithExpression_UsesMappedPropertyAsConcurrencyToken()
+    {
+        var modelBuilder = MakeModelBuilderWith(typeof(ModelWithEtag));
+
+        modelBuilder.Entity<ModelWithEtag>().UseObjectETagConcurrency(e => e.ETag);
+        var entityType = modelBuilder.Model.FindEntityType(typeof(ModelWithEtag))!;
+        var etagProperty = entityType.FindProperty(nameof(ModelWithEtag.ETag));
+
+        etagProperty.ShouldNotBeNull();
+        etagProperty.IsConcurrencyToken.ShouldBeTrue();
+        entityType.FindAnnotation(ETagConcurrencyEnabledAnnotation)!.Value.ShouldBe(true);
+        entityType.FindAnnotation(ETagConcurrencyPropertyNameAnnotation)!.Value.ShouldBe(nameof(ModelWithEtag.ETag));
     }
 }

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageDatabaseTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageDatabaseTests.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
+using CloudStorageORM.Abstractions;
+using CloudStorageORM.Extensions;
 using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Interfaces.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
@@ -88,6 +90,51 @@ public class CloudStorageDatabaseTests
     }
 
     [Fact]
+    public async Task SaveChangesAsync_ModifiedEntry_WithEtagConcurrency_UsesConditionalSaveAndRefreshesTrackedValues()
+    {
+        var fixture = CreateEtagFixture();
+        var entity = new EtagDbUser { Id = "7", Name = "Before" };
+        fixture.Context.Attach(entity);
+        fixture.Context.Entry(entity).Property("ETag").OriginalValue = "etag-1";
+        fixture.Context.Entry(entity).Property("ETag").CurrentValue = "etag-1";
+        entity.Name = "After";
+        fixture.Context.Entry(entity).State = EntityState.Modified;
+
+        var entries = GetUpdateEntries(fixture.Context);
+        fixture.PathResolverMock.Setup(x => x.GetPath(It.IsAny<IUpdateEntry>())).Returns("users/7.json");
+        fixture.StorageProviderMock
+            .Setup(x => x.SaveAsync("users/7.json", It.IsAny<object>(), "etag-1"))
+            .ReturnsAsync("etag-2");
+
+        var changes = await fixture.Database.SaveChangesAsync(entries);
+
+        changes.ShouldBe(1);
+        fixture.StorageProviderMock.Verify(x => x.SaveAsync("users/7.json", It.IsAny<object>(), "etag-1"), Times.Once);
+        fixture.Context.Entry(entity).Property("ETag").OriginalValue.ShouldBe("etag-2");
+        entity.ETag.ShouldBe("etag-2");
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_ModifiedEntry_WithEtagConcurrencyConflict_ThrowsDbUpdateConcurrencyException()
+    {
+        var fixture = CreateEtagFixture();
+        var entity = new EtagDbUser { Id = "8", Name = "Before" };
+        fixture.Context.Attach(entity);
+        fixture.Context.Entry(entity).Property("ETag").OriginalValue = "etag-1";
+        fixture.Context.Entry(entity).Property("ETag").CurrentValue = "etag-1";
+        entity.Name = "After";
+        fixture.Context.Entry(entity).State = EntityState.Modified;
+
+        var entries = GetUpdateEntries(fixture.Context);
+        fixture.PathResolverMock.Setup(x => x.GetPath(It.IsAny<IUpdateEntry>())).Returns("users/8.json");
+        fixture.StorageProviderMock
+            .Setup(x => x.SaveAsync("users/8.json", It.IsAny<object>(), "etag-1"))
+            .ThrowsAsync(new StoragePreconditionFailedException("users/8.json"));
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => fixture.Database.SaveChangesAsync(entries));
+    }
+
+    [Fact]
     public async Task SaveChangesAsync_InsideTransactionThenRollback_DoesNotPersist()
     {
         var fixture = CreateFixture();
@@ -147,11 +194,11 @@ public class CloudStorageDatabaseTests
             .Setup(x => x.ListAsync("users"))
             .ReturnsAsync(["users/1.json", "users/2.json"]);
         fixture.StorageProviderMock
-            .Setup(x => x.ReadAsync<DbUser>("users/1.json"))
-            .ReturnsAsync(new DbUser { Id = "1", Name = "One" });
+            .Setup(x => x.ReadWithMetadataAsync<DbUser>("users/1.json"))
+            .ReturnsAsync(new StorageObject<DbUser>(new DbUser { Id = "1", Name = "One" }, "etag-1", true));
         fixture.StorageProviderMock
-            .Setup(x => x.ReadAsync<DbUser>("users/2.json"))
-            .ReturnsAsync((DbUser)null!);
+            .Setup(x => x.ReadWithMetadataAsync<DbUser>("users/2.json"))
+            .ReturnsAsync(new StorageObject<DbUser>(null, null, false));
 
         var list = await fixture.Database.ToListAsync<DbUser>("users");
 
@@ -167,8 +214,8 @@ public class CloudStorageDatabaseTests
             .Setup(x => x.GetPath(typeof(DbUser), "42"))
             .Returns("users/42.json");
         fixture.StorageProviderMock
-            .Setup(x => x.ReadAsync<DbUser>("users/42.json"))
-            .ReturnsAsync(new DbUser { Id = "42", Name = "Found" });
+            .Setup(x => x.ReadWithMetadataAsync<DbUser>("users/42.json"))
+            .ReturnsAsync(new StorageObject<DbUser>(new DbUser { Id = "42", Name = "Found" }, "etag-42", true));
 
         var entity = await fixture.Database.TryLoadByPrimaryKeyAsync<DbUser>("42");
 
@@ -184,12 +231,30 @@ public class CloudStorageDatabaseTests
             .Setup(x => x.GetPath(typeof(DbUser), "404"))
             .Returns("users/404.json");
         fixture.StorageProviderMock
-            .Setup(x => x.ReadAsync<DbUser>("users/404.json"))
-            .ReturnsAsync((DbUser)null!);
+            .Setup(x => x.ReadWithMetadataAsync<DbUser>("users/404.json"))
+            .ReturnsAsync(new StorageObject<DbUser>(null, null, false));
 
         var entity = await fixture.Database.TryLoadByPrimaryKeyAsync<DbUser>("404");
 
         entity.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TryLoadByPrimaryKeyAsync_WithEtagConcurrency_PopulatesTrackedEtagAndIETag()
+    {
+        var fixture = CreateEtagFixture();
+        fixture.PathResolverMock
+            .Setup(x => x.GetPath(typeof(EtagDbUser), "9"))
+            .Returns("users/9.json");
+        fixture.StorageProviderMock
+            .Setup(x => x.ReadWithMetadataAsync<EtagDbUser>("users/9.json"))
+            .ReturnsAsync(new StorageObject<EtagDbUser>(new EtagDbUser { Id = "9", Name = "Tracked" }, "etag-9", true));
+
+        var entity = await fixture.Database.TryLoadByPrimaryKeyAsync<EtagDbUser>("9", fixture.Context);
+
+        entity.ShouldNotBeNull();
+        entity.ETag.ShouldBe("etag-9");
+        fixture.Context.Entry(entity).Property("ETag").OriginalValue.ShouldBe("etag-9");
     }
 
     [Fact]
@@ -236,8 +301,8 @@ public class CloudStorageDatabaseTests
             .Setup(x => x.GetPath(typeof(DbUser), "42"))
             .Returns("users/42.json");
         fixture.StorageProviderMock
-            .Setup(x => x.ReadAsync<DbUser>("users/42.json"))
-            .ReturnsAsync(new DbUser { Id = "42", Name = "Found" });
+            .Setup(x => x.ReadWithMetadataAsync<DbUser>("users/42.json"))
+            .ReturnsAsync(new StorageObject<DbUser>(new DbUser { Id = "42", Name = "Found" }, "etag-42", true));
 
         var externalProvider = new CloudStorageQueryProvider(fixture.Database, fixture.PathResolverMock.Object);
         var queryable = new CloudStorageQueryable<DbUser>(externalProvider);
@@ -262,11 +327,11 @@ public class CloudStorageDatabaseTests
             .Setup(x => x.ListAsync("users"))
             .ReturnsAsync(["users/1.json", "users/2.json"]);
         fixture.StorageProviderMock
-            .Setup(x => x.ReadAsync<DbUser?>("users/1.json"))
-            .ReturnsAsync(new DbUser { Id = "1", Name = "One" });
+            .Setup(x => x.ReadWithMetadataAsync<DbUser?>("users/1.json"))
+            .ReturnsAsync(new StorageObject<DbUser?>(new DbUser { Id = "1", Name = "One" }, "etag-1", true));
         fixture.StorageProviderMock
-            .Setup(x => x.ReadAsync<DbUser?>("users/2.json"))
-            .ReturnsAsync(new DbUser { Id = "2", Name = "Two" });
+            .Setup(x => x.ReadWithMetadataAsync<DbUser?>("users/2.json"))
+            .ReturnsAsync(new StorageObject<DbUser?>(new DbUser { Id = "2", Name = "Two" }, "etag-2", true));
 
         var expression = fixture.Context.Users.Where(u => u.Name == "One").Expression;
         var compiled = database.CompileQuery<IEnumerable<DbUser>>(expression, async: false);
@@ -337,6 +402,37 @@ public class CloudStorageDatabaseTests
             transactionManager);
     }
 
+    private static EtagDatabaseFixture CreateEtagFixture()
+    {
+        var dbOptions = new DbContextOptionsBuilder<EtagDatabaseTestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new EtagDatabaseTestDbContext(dbOptions);
+
+        var storageProviderMock = new Mock<IStorageProvider>();
+        var pathResolverMock = new Mock<IBlobPathResolver>();
+        var creatorMock = new Mock<IDatabaseCreator>();
+        var strategyFactoryMock = new Mock<IExecutionStrategyFactory>();
+        var currentDbContextMock = new Mock<ICurrentDbContext>();
+        var transactionManager = new CloudStorageTransactionManager();
+        currentDbContextMock.SetupGet(x => x.Context).Returns(context);
+
+        var database = new CloudStorageDatabase(
+            context.Model,
+            creatorMock.Object,
+            strategyFactoryMock.Object,
+            storageProviderMock.Object,
+            currentDbContextMock.Object,
+            pathResolverMock.Object,
+            transactionManager);
+
+        return new EtagDatabaseFixture(
+            database,
+            context,
+            storageProviderMock,
+            pathResolverMock);
+    }
+
     private sealed record DatabaseFixture(
         CloudStorageDatabase Database,
         DatabaseTestDbContext Context,
@@ -344,6 +440,12 @@ public class CloudStorageDatabaseTests
         Mock<IBlobPathResolver> PathResolverMock,
         Mock<IDatabaseCreator> CreatorMock,
         CloudStorageTransactionManager TransactionManager);
+
+    private sealed record EtagDatabaseFixture(
+        CloudStorageDatabase Database,
+        EtagDatabaseTestDbContext Context,
+        Mock<IStorageProvider> StorageProviderMock,
+        Mock<IBlobPathResolver> PathResolverMock);
 }
 
 public class DatabaseTestDbContext(DbContextOptions<DatabaseTestDbContext> options) : DbContext(options)
@@ -358,8 +460,27 @@ public class DatabaseTestDbContext(DbContextOptions<DatabaseTestDbContext> optio
 
 public class DbUser
 {
-    [MaxLength(100)]
-    public string Id { get; init; } = string.Empty;
-    [MaxLength(100)]
-    public string Name { get; set; } = string.Empty;
+    [MaxLength(100)] public string Id { get; init; } = string.Empty;
+    [MaxLength(100)] public string Name { get; set; } = string.Empty;
+}
+
+public sealed class EtagDatabaseTestDbContext(DbContextOptions<EtagDatabaseTestDbContext> options) : DbContext(options)
+{
+    public DbSet<EtagDbUser> Users => Set<EtagDbUser>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<EtagDbUser>().HasKey(x => x.Id);
+        modelBuilder.Entity<EtagDbUser>().UseObjectETagConcurrency();
+    }
+}
+
+public sealed class EtagDbUser : IETag
+{
+    [MaxLength(100)] public string Id { get; init; } = string.Empty;
+
+    [MaxLength(100)] public string Name { get; set; } = string.Empty;
+
+    // ReSharper disable once EntityFramework.ModelValidation.UnlimitedStringLength
+    public string? ETag { get; set; }
 }

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageQueryProviderTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageQueryProviderTests.cs
@@ -536,6 +536,8 @@ public class QueryTestUser
 public class RangeQueryTestUser
 {
     public int Id { get; init; }
+
+    // ReSharper disable once EntityFramework.ModelValidation.UnlimitedStringLength
     public string Name { get; init; } = string.Empty;
 }
 

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageQueryProviderTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageQueryProviderTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.ComponentModel.DataAnnotations;
+using CloudStorageORM.Abstractions;
 using CloudStorageORM.Enums;
 using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
@@ -44,8 +45,11 @@ public class CloudStorageQueryProviderTests
         {
             var path = $"{blobName}/{user.Id}.json";
             storageProviderMock
-                .Setup(x => x.ReadAsync<QueryTestUser>(path))
-                .ReturnsAsync(user);
+                .Setup(x => x.ReadWithMetadataAsync<QueryTestUser>(path))
+                .ReturnsAsync(new StorageObject<QueryTestUser>(user, "etag", true));
+            storageProviderMock
+                .Setup(x => x.ReadWithMetadataAsync<QueryTestUser?>(path))
+                .ReturnsAsync(new StorageObject<QueryTestUser?>(user, "etag", true));
         }
 
         var database = BuildDatabase(storageProviderMock.Object);
@@ -73,11 +77,11 @@ public class CloudStorageQueryProviderTests
         {
             var path = $"{blobName}/{user.Id}.json";
             storageProviderMock
-                .Setup(x => x.ReadAsync<RangeQueryTestUser>(path))
-                .ReturnsAsync(user);
+                .Setup(x => x.ReadWithMetadataAsync<RangeQueryTestUser>(path))
+                .ReturnsAsync(new StorageObject<RangeQueryTestUser>(user, "etag", true));
             storageProviderMock
-                .Setup(x => x.ReadAsync<RangeQueryTestUser?>(path))
-                .ReturnsAsync(user);
+                .Setup(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>(path))
+                .ReturnsAsync(new StorageObject<RangeQueryTestUser?>(user, "etag", true));
         }
 
         var database = BuildRangeDatabase(storageProviderMock.Object);
@@ -200,7 +204,7 @@ public class CloudStorageQueryProviderTests
 
         // ListAsync should NOT have been called – we resolved directly via key path.
         storageMock.Verify(x => x.ListAsync(It.IsAny<string>()), Times.Never);
-        storageMock.Verify(x => x.ReadAsync<QueryTestUser>($"{blobName}/{UserId1}.json"), Times.Once);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<QueryTestUser>($"{blobName}/{UserId1}.json"), Times.Once);
     }
 
     [Fact]
@@ -318,7 +322,7 @@ public class CloudStorageQueryProviderTests
         result.ShouldNotBeNull();
         result.Id.ShouldBe(UserId2);
         storageMock.Verify(x => x.ListAsync(It.IsAny<string>()), Times.Never);
-        storageMock.Verify(x => x.ReadAsync<QueryTestUser>($"{blobName}/{UserId2}.json"), Times.Once);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<QueryTestUser>($"{blobName}/{UserId2}.json"), Times.Once);
     }
 
     [Fact]
@@ -361,9 +365,9 @@ public class CloudStorageQueryProviderTests
         result.ShouldNotBeNull();
         result.Id.ShouldBe(2);
         storageMock.Verify(x => x.ListAsync(blobName), Times.Once);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/1.json"), Times.Never);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/2.json"), Times.Once);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/3.json"), Times.Once);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/1.json"), Times.Never);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/2.json"), Times.Once);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/3.json"), Times.Once);
     }
 
     [Fact]
@@ -386,9 +390,9 @@ public class CloudStorageQueryProviderTests
         results.Count.ShouldBe(2);
         results.Select(x => x.Id).Order().ShouldBe([1, 2]);
         storageMock.Verify(x => x.ListAsync(blobName), Times.Once);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/1.json"), Times.Once);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/2.json"), Times.Once);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/3.json"), Times.Never);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/1.json"), Times.Once);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/2.json"), Times.Once);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/3.json"), Times.Never);
     }
 
     [Fact]
@@ -410,9 +414,9 @@ public class CloudStorageQueryProviderTests
 
         result.ShouldNotBeNull();
         result.Id.ShouldBe(2);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/1.json"), Times.Never);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/2.json"), Times.Once);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/3.json"), Times.Never);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/1.json"), Times.Never);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/2.json"), Times.Once);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/3.json"), Times.Never);
     }
 
     [Fact]
@@ -434,9 +438,9 @@ public class CloudStorageQueryProviderTests
 
         result.ShouldNotBeNull();
         result.Id.ShouldBe(3);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/1.json"), Times.Never);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/2.json"), Times.Never);
-        storageMock.Verify(x => x.ReadAsync<RangeQueryTestUser?>($"{blobName}/3.json"), Times.Once);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/1.json"), Times.Never);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/2.json"), Times.Never);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<RangeQueryTestUser?>($"{blobName}/3.json"), Times.Once);
     }
 
     [Fact]
@@ -519,8 +523,10 @@ public class CloudStorageQueryProviderTests
     private static void storageProviderMock_SetupMissingRead(
         Mock<IStorageProvider> mock, string path)
     {
-        mock.Setup(x => x.ReadAsync<QueryTestUser?>(It.Is<string>(p => p == path)))
-            .ReturnsAsync((QueryTestUser?)null);
+        mock.Setup(x => x.ReadWithMetadataAsync<QueryTestUser>(It.Is<string>(p => p == path)))
+            .ReturnsAsync(new StorageObject<QueryTestUser>(null, null, false));
+        mock.Setup(x => x.ReadWithMetadataAsync<QueryTestUser?>(It.Is<string>(p => p == path)))
+            .ReturnsAsync(new StorageObject<QueryTestUser?>(null, null, false));
     }
 }
 

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransactionManagerTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransactionManagerTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CloudStorageORM.Abstractions;
 using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
 using Shouldly;
@@ -275,9 +276,11 @@ public class CloudStorageTransactionManagerDurabilityTests
         await manager.StageDeleteOperationAsync("users/b.json", CancellationToken.None);
         await tx2.RollbackAsync();
 
-        storage.GetAllKeys().Any(k => k.Contains($"__cloudstorageorm/tx/{tx1.TransactionId:D}/", StringComparison.Ordinal))
+        storage.GetAllKeys().Any(k =>
+                k.Contains($"__cloudstorageorm/tx/{tx1.TransactionId:D}/", StringComparison.Ordinal))
             .ShouldBeTrue();
-        storage.GetAllKeys().Any(k => k.Contains($"__cloudstorageorm/tx/{tx2.TransactionId:D}/", StringComparison.Ordinal))
+        storage.GetAllKeys().Any(k =>
+                k.Contains($"__cloudstorageorm/tx/{tx2.TransactionId:D}/", StringComparison.Ordinal))
             .ShouldBeTrue();
     }
 
@@ -323,6 +326,12 @@ public class CloudStorageTransactionManagerDurabilityTests
             return Task.CompletedTask;
         }
 
+        public Task<string?> SaveAsync<T>(string path, T entity, string? ifMatchETag)
+        {
+            SaveAsync(path, entity);
+            return Task.FromResult<string?>("in-memory-etag");
+        }
+
         public Task<T> ReadAsync<T>(string path)
         {
             lock (_sync)
@@ -336,6 +345,13 @@ public class CloudStorageTransactionManagerDurabilityTests
             }
         }
 
+        public async Task<StorageObject<T>> ReadWithMetadataAsync<T>(string path)
+        {
+            var value = await ReadAsync<T>(path);
+            var exists = !EqualityComparer<T>.Default.Equals(value, default!);
+            return new StorageObject<T>(value, exists ? "in-memory-etag" : null, exists);
+        }
+
         public Task DeleteAsync(string path)
         {
             lock (_sync)
@@ -345,6 +361,8 @@ public class CloudStorageTransactionManagerDurabilityTests
 
             return Task.CompletedTask;
         }
+
+        public Task DeleteAsync(string path, string? ifMatchETag) => DeleteAsync(path);
 
         public Task<List<string>> ListAsync(string folderPath)
         {
@@ -391,6 +409,7 @@ public class CloudStorageTransactionManagerDurabilityTests
     {
         // ReSharper disable once PropertyCanBeMadeInitOnly.Local
         public string Id { get; set; } = string.Empty;
+
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
         public string Name { get; set; } = string.Empty;
     }


### PR DESCRIPTION
## 📋 Description
This PR adds ETag-based optimistic concurrency support to CloudStorageORM.

It introduces `StorageObject<T>` to encapsulate the stored value, `ETag`, and existence state, and adds `IETag` for entities that optionally expose an `ETag` property. The storage pipeline now supports `SaveAsync` and `DeleteAsync` operations with ETag conditions, and both Azure Blob Storage and AWS S3 providers have been updated to enforce concurrency checks.

Model configuration has also been updated so entities can be configured for ETag concurrency, and tests were added to cover the new concurrency scenarios.

## 🔎 Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please specify):

## 🧪 How to test
- Run the unit and integration test suites.
- Verify save/delete operations with matching and mismatching ETags.
- Validate Azure concurrency behavior with Azurite-backed tests.
- Validate AWS concurrency behavior with LocalStack-backed tests.

## 📚 Checklist
- [x] Code follows project standards
- [x] Tests were added or updated
- [x] Documentation was updated if necessary
- [x] Build and tests are passing

