### PR TITLE
Preserve ETag preconditions in staged transactions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "nuget"
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,14 @@ Please include:
 - `Closes #issue_number` when applicable
 - any local setup notes reviewers need (for example, Azurite or LocalStack)
 
+### Dependabot PRs
+
+For PRs opened by Dependabot (`.github/dependabot.yml`):
+
+- keep scope focused on dependency or action updates
+- keep required CI checks green before merge
+- include follow-up notes when a version bump needs behavior or docs changes
+
 ---
 
 ## Coding style requirements
@@ -212,6 +220,7 @@ The most likely files to update are:
 - `docs/testing-with-azurite.md`
 - `docs/testing-with-localstack.md`
 - `docs/ci.md`
+- `.github/dependabot.yml`
 - `docfx.json`
 - `docs/toc.yml`
 - `docs/index.md`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Support for **Google Cloud Storage** remains on the roadmap.
 
 ## ✨ Current status
 
-- ✅ Current release line: `v1.0.13`
+- ✅ Current release line: `v1.0.14`
 - ✅ Targets `net10.0`
 - ✅ Azure Blob Storage provider is implemented
 - ✅ AWS S3 provider is implemented
@@ -29,6 +29,8 @@ Support for **Google Cloud Storage** remains on the roadmap.
 - ✅ Sample app runs the same CRUD flow against EF InMemory, Azure, and AWS
 - ✅ Unit + integration tests run locally with Azurite and LocalStack
 - ✅ Coverage collection is wired with Coverlet + ReportGenerator
+- ✅ `v1.0.14` preserves `If-Match` ETag preconditions for staged transaction save/delete replay and surfaces conflicts as `DbUpdateConcurrencyException`
+- ✅ `v1.0.14` enables Dependabot for NuGet and GitHub Actions updates via `.github/dependabot.yml`
 - ✅ `v1.0.13` adds server-side `Skip`/`Take` pushdown for supported query shapes
 - ✅ `v1.0.13` refreshes observability guidance for logging, tracing, and diagnostics options
 - 🚧 Google Cloud Storage provider is planned

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,22 @@ This document outlines the evolution of CloudStorageORM from the current release
 
 ## ✅ Current released version
 
+### v1.0.14
+
+- Version bump to `1.0.14` for the current release line.
+- Preserve staged transaction `If-Match` ETag preconditions during commit replay for update/delete operations.
+- Surface stale-ETag transactional commit conflicts as `DbUpdateConcurrencyException`.
+- Add Azure and AWS integration coverage for stale-ETag transactional commit scenarios.
+- Enable Dependabot automation for NuGet and GitHub Actions updates through `.github/dependabot.yml`.
+
+
+---
+
+## 📋 Previous releases
+
 ### v1.0.13
 
-- Version bump to `1.0.13` for the current release line
+- Version bump to `1.0.13` for the previous release line
 - Documentation refreshed to keep local test guidance aligned with CI emulator setup
 - Server-side `Skip`/`Take` pushdown for supported query shapes
 - Observability improvements and refreshed guidance for logging, tracing, and diagnostics options
@@ -17,10 +30,6 @@ This document outlines the evolution of CloudStorageORM from the current release
   - The storage pipeline now supports SaveAsync and DeleteAsync operations with ETag conditions, and both Azure Blob Storage and AWS S3 providers have been updated to enforce concurrency checks.
   - Model configuration has also been updated so entities can be configured for ETag concurrency, and tests were added to cover the new concurrency scenarios.
 
-
----
-
-## 📋 Previous releases
 
 ### v1.0.12
 

--- a/TODO-LIST
+++ b/TODO-LIST
@@ -17,20 +17,6 @@ Backlog policy
 
 P0 - Correctness and recoverability (must complete before new provider expansion)
 
-Issue P0-01
-Title: Preserve ETag preconditions in staged transactions
-Scope:
-- Add `ifMatchETag` support to staged operation model and durable manifest (`src/CloudStorageORM/Infrastructure/CloudStorageTransactionManager.cs`).
-- Forward original ETag values when staging save/delete inside transactions (`src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs`).
-- Replay staged operations with provider conditional calls (`src/CloudStorageORM/Infrastructure/CloudStorageTransactionManager.cs`).
-Acceptance Criteria:
-- [ ] Updates/deletes staged in a transaction honor ETag preconditions during commit replay.
-- [ ] Conflicts surface as `DbUpdateConcurrencyException` in transactional flows.
-- [ ] No regression for non-transactional save/delete behavior.
-Test Checklist:
-- [ ] Add/extend unit tests in `tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransactionManagerTests.cs`.
-- [ ] Add integration coverage in `tests/CloudStorageORM.IntegrationTests/**` for Azure and AWS stale-ETag commit scenarios.
-
 Issue P0-02
 Title: Make commit replay crash-safe and idempotent
 Scope:
@@ -217,7 +203,7 @@ Test Checklist:
 
 Execution tracking
 - [ ] Create epic: "Enterprise Readiness".
-- [ ] Milestone A: Transaction correctness and recovery (P0-01..P0-05).
+- [ ] Milestone A: Transaction correctness and recovery (P0-02..P0-05).
 - [ ] Milestone B: Security, observability, auditability (P1-01..P1-05).
 - [ ] Milestone C: Platform maturity and operations (P2-01..P2-04).
 

--- a/docs/CloudStorageORM.md
+++ b/docs/CloudStorageORM.md
@@ -1,9 +1,9 @@
 # 📦 CloudStorageORM - Library Documentation
 
 **Target Framework**: `net10.0`  
-**Current Release**: `v1.0.13`  
+**Current Release**: `v1.0.14`  
 **Language Version**: `C# 14`  
-**EF Core Packages**: `Microsoft.EntityFrameworkCore 9.0.4`, `Microsoft.EntityFrameworkCore.Relational 9.0.4`  
+**EF Core Packages**: `Microsoft.EntityFrameworkCore 10.0.5`, `Microsoft.EntityFrameworkCore.Relational 10.0.5`  
 **Testing**: `xUnit`, `Shouldly`, `Moq`, `Coverlet`, `ReportGenerator`
 
 ---
@@ -22,11 +22,12 @@ The current branch is focused on:
 - CRUD flows that behave similarly to the EF InMemory provider for the sample app
 - Unit and integration test coverage around infrastructure, queries, validators, and provider behavior
 
-## Release notes for `v1.0.13`
+## Release notes for `v1.0.14`
 
-- Server-side `Skip`/`Take` pushdown is now supported for eligible query shapes.
-- Observability guidance has been refreshed to reflect the logging, tracing, and diagnostics options available in `CloudStorageOptions.Observability`.
-- The release line has been advanced to `v1.0.13` in the package metadata and public docs.
+- Transaction commit replay now preserves staged `If-Match` ETag preconditions for update/delete operations.
+- Transactional stale-ETag conflicts now surface as `DbUpdateConcurrencyException` during commit replay.
+- Added Azure and AWS integration coverage for stale-ETag commit conflicts in transactional flows.
+- Enabled Dependabot automation for NuGet and GitHub Actions updates via `.github/dependabot.yml`.
 
 ---
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -5,7 +5,7 @@ Package publishing is handled by `.github/workflows/publish.yml`, which validate
 `README.md` and correct repository/readme metadata before push, then publishes to both NuGet.org and GitHub Packages.
 The same CI workflow also runs a parallel DocFX documentation job that builds the static site and deploys it by branch:
 `main` pushes publish to `gh-pages`, while `feature/docs` pushes publish to `gh-pages-preview` for pre-merge validation.
-Publishing runs on `v*.*.*` tags (for example, `v1.0.13`) or manual dispatch.
+ePublishing runs on `v*.*.*` tags (for example, `v1.0.13`) or manual dispatch.
 
 ---
 
@@ -17,6 +17,20 @@ The workflow runs on:
 - push to `feature/docs`
 - pull request targeting `main`, `feature/**`, `bug/**`, or `hotfix/**`
 - changes under `_site/**` are ignored at trigger time
+
+---
+
+## Dependabot updates
+
+Dependency automation is configured in `.github/dependabot.yml`.
+
+- ecosystems: `nuget` and `github-actions`
+- cadence: weekly on Monday (UTC)
+- PR limits: `10` (`nuget`), `5` (`github-actions`)
+- labels: `dependencies` plus ecosystem-specific labels (`nuget`, `github-actions`)
+- commit prefixes: `deps` (`nuget`) and `ci` (`github-actions`)
+
+Dependabot pull requests run the same CI checks as any other pull request targeting supported branches.
 
 ---
 

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -97,6 +97,15 @@ catch (DbUpdateConcurrencyException ex)
 }
 ```
 
+### Concurrency inside transactions
+
+When changes are staged inside `BeginTransactionAsync()` and later committed, CloudStorageORM preserves the original
+ETag preconditions in staged operations.
+
+- Transactional commit replay still sends conditional update/delete requests.
+- Stale ETags during replay surface as `DbUpdateConcurrencyException` from `CommitAsync()`.
+- Non-transactional and transactional concurrency behavior are aligned.
+
 ## Conflict handling patterns
 
 ### Pattern 1: Reload and retry

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -77,6 +77,13 @@ When you call `CommitAsync()`:
 2. Operations are replayed in sequence
 3. Manifest state changes to `Completed`
 
+When optimistic concurrency is enabled (`UseObjectETagConcurrency(...)`), staged updates and deletes keep the
+original `If-Match` ETag precondition in the durable manifest. During replay, commit uses those same conditional
+provider calls.
+
+If the object changed after staging but before commit replay, `CommitAsync()` throws `DbUpdateConcurrencyException`.
+This matches the non-transactional `SaveChangesAsync()` conflict behavior.
+
 ### Phase 3: Recovery
 
 On startup of a new transaction manager instance:

--- a/src/CloudStorageORM/CloudStorageORM.csproj
+++ b/src/CloudStorageORM/CloudStorageORM.csproj
@@ -8,7 +8,7 @@
 
         <!-- NuGet package metadata -->
         <PackageId>CloudStorageORM</PackageId>
-        <Version>1.0.13</Version>
+        <Version>1.0.14</Version>
         <Authors>Rodrigo Zavalik Castro</Authors>
         <PackageReadmeFile>README.md</PackageReadmeFile>
 

--- a/src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs
@@ -242,7 +242,8 @@ public class CloudStorageDatabase(
         {
             if (manager.IsDurableJournalEnabled)
             {
-                await manager.StageSaveOperationAsync(path, entity, cancellationToken);
+                var stagedIfMatchETag = useConditionalRequest ? ifMatchETag : null;
+                await manager.StageSaveOperationAsync(path, entity, stagedIfMatchETag, cancellationToken);
             }
             else
             {
@@ -278,7 +279,8 @@ public class CloudStorageDatabase(
         {
             if (manager.IsDurableJournalEnabled)
             {
-                await manager.StageDeleteOperationAsync(path, cancellationToken);
+                var stagedIfMatchETag = useConditionalRequest ? ifMatchETag : null;
+                await manager.StageDeleteOperationAsync(path, stagedIfMatchETag, cancellationToken);
             }
             else
             {

--- a/src/CloudStorageORM/Infrastructure/CloudStorageDbContextTransaction.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageDbContextTransaction.cs
@@ -44,8 +44,14 @@ public sealed class CloudStorageDbContextTransaction(CloudStorageTransactionMana
             return;
         }
 
-        await transactionManager.CommitTransactionInternalAsync(this, cancellationToken);
-        _completed = true;
+        try
+        {
+            await transactionManager.CommitTransactionInternalAsync(this, cancellationToken);
+        }
+        finally
+        {
+            _completed = true;
+        }
     }
 
     /// <inheritdoc />
@@ -56,8 +62,14 @@ public sealed class CloudStorageDbContextTransaction(CloudStorageTransactionMana
             return;
         }
 
-        await transactionManager.RollbackTransactionInternalAsync(this, cancellationToken);
-        _completed = true;
+        try
+        {
+            await transactionManager.RollbackTransactionInternalAsync(this, cancellationToken);
+        }
+        finally
+        {
+            _completed = true;
+        }
     }
 
     /// <inheritdoc />

--- a/src/CloudStorageORM/Infrastructure/CloudStorageTransactionManager.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageTransactionManager.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using CloudStorageORM.Interfaces.StorageProviders;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace CloudStorageORM.Infrastructure;
@@ -144,7 +145,11 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
         }
     }
 
-    internal async Task StageSaveOperationAsync(string path, object entity, CancellationToken cancellationToken)
+    internal async Task StageSaveOperationAsync(
+        string path,
+        object entity,
+        string? ifMatchETag,
+        CancellationToken cancellationToken)
     {
         var (transaction, manifest) = GetActiveTransactionState();
 
@@ -165,14 +170,15 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
                 Sequence = manifest.Operations.Count,
                 Kind = DurableTransactionOperationKind.Save,
                 Path = path,
-                PayloadJson = payloadJson
+                PayloadJson = payloadJson,
+                IfMatchETag = ifMatchETag
             });
         }
 
         await PersistManifestAsync(manifest, cancellationToken);
     }
 
-    internal async Task StageDeleteOperationAsync(string path, CancellationToken cancellationToken)
+    internal async Task StageDeleteOperationAsync(string path, string? ifMatchETag, CancellationToken cancellationToken)
     {
         var (transaction, manifest) = GetActiveTransactionState();
 
@@ -190,7 +196,8 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
             {
                 Sequence = manifest.Operations.Count,
                 Kind = DurableTransactionOperationKind.Delete,
-                Path = path
+                Path = path,
+                IfMatchETag = ifMatchETag
             });
         }
 
@@ -333,14 +340,57 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
                 case DurableTransactionOperationKind.Save:
                     var payloadJson = string.IsNullOrWhiteSpace(operation.PayloadJson) ? "{}" : operation.PayloadJson;
                     var payload = JsonSerializer.Deserialize<JsonElement>(payloadJson);
-                    await _storageProvider.SaveAsync(operation.Path, payload);
+                    await SaveDurableOperationAsync(operation, payload);
                     break;
 
                 case DurableTransactionOperationKind.Delete:
-                    await _storageProvider.DeleteAsync(operation.Path);
+                    await DeleteDurableOperationAsync(operation);
                     break;
             }
         }
+    }
+
+    private async Task SaveDurableOperationAsync(DurableTransactionOperation operation, JsonElement payload)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(operation.IfMatchETag))
+            {
+                await _storageProvider!.SaveAsync(operation.Path, payload);
+                return;
+            }
+
+            await _storageProvider!.SaveAsync(operation.Path, payload, operation.IfMatchETag);
+        }
+        catch (StoragePreconditionFailedException ex)
+        {
+            throw CreateConcurrencyException(operation.Path, ex);
+        }
+    }
+
+    private async Task DeleteDurableOperationAsync(DurableTransactionOperation operation)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(operation.IfMatchETag))
+            {
+                await _storageProvider!.DeleteAsync(operation.Path);
+                return;
+            }
+
+            await _storageProvider!.DeleteAsync(operation.Path, operation.IfMatchETag);
+        }
+        catch (StoragePreconditionFailedException ex)
+        {
+            throw CreateConcurrencyException(operation.Path, ex);
+        }
+    }
+
+    private static DbUpdateConcurrencyException CreateConcurrencyException(string path, Exception innerException)
+    {
+        return new DbUpdateConcurrencyException(
+            $"The operation expected the object ETag to match for '{path}', but it was updated by another process.",
+            innerException);
     }
 
     private static string GetManifestPath(Guid transactionId)
@@ -388,10 +438,11 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
 
     private sealed class DurableTransactionOperation
     {
-        public int Sequence { get; set; }
-        public DurableTransactionOperationKind Kind { get; set; }
-        public string Path { get; set; } = string.Empty;
-        public string? PayloadJson { get; set; }
+        public int Sequence { get; init; }
+        public DurableTransactionOperationKind Kind { get; init; }
+        public string Path { get; init; } = string.Empty;
+        public string? PayloadJson { get; init; }
+        public string? IfMatchETag { get; init; }
     }
 
     private sealed class DurableTransactionManifest

--- a/src/CloudStorageORM/Providers/Aws/StorageProviders/AwsS3StorageProvider.cs
+++ b/src/CloudStorageORM/Providers/Aws/StorageProviders/AwsS3StorageProvider.cs
@@ -210,6 +210,15 @@ public class AwsS3StorageProvider : IStorageProvider
 
         try
         {
+            if (!string.IsNullOrWhiteSpace(ifMatchETag))
+            {
+                var currentEtag = await GetObjectETagAsync(path);
+                if (!ETagMatches(currentEtag, ifMatchETag))
+                {
+                    throw new StoragePreconditionFailedException(path);
+                }
+            }
+
             await _s3Client.DeleteObjectAsync(new DeleteObjectRequest
             {
                 BucketName = _bucketName,

--- a/src/CloudStorageORM/Repositories/CloudStorageRepository.cs
+++ b/src/CloudStorageORM/Repositories/CloudStorageRepository.cs
@@ -1,5 +1,5 @@
-using CloudStorageORM.Interfaces.StorageProviders;
 using CloudStorageORM.Interfaces.Repositories;
+using CloudStorageORM.Interfaces.StorageProviders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/tests/CloudStorageORM.IntegrationTests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
+++ b/tests/CloudStorageORM.IntegrationTests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
@@ -1,4 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+using CloudStorageORM.Enums;
+using CloudStorageORM.Extensions;
+using CloudStorageORM.Infrastructure;
 using CloudStorageORM.IntegrationTests.Aws;
+using CloudStorageORM.Options;
+using CloudStorageORM.Providers.Aws.StorageProviders;
+using Microsoft.EntityFrameworkCore;
 using Shouldly;
 
 namespace CloudStorageORM.IntegrationTests.AWS.Aws.StorageProviders;
@@ -72,6 +79,104 @@ public class AwsS3StorageProviderTests(LocalStackFixture fixture) : IClassFixtur
         ex.Message.ShouldContain("changed by another writer");
     }
 
+    [Fact]
+    public async Task TransactionalCommit_WithStaleEtagOnSave_ShouldThrowDbUpdateConcurrencyException()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, bucketName) = await CreateIsolatedProviderAsync(fixture, "save");
+        var id = $"tx-save-{Guid.NewGuid():N}";
+        var path = new BlobPathResolver(provider).GetPath(typeof(AwsTransactionalEntity), id);
+
+        await provider.SaveAsync(path, new AwsTransactionalEntity { Id = id, Name = "v1" });
+        var original = await provider.ReadWithMetadataAsync<AwsTransactionalEntity>(path);
+
+        await using var context = CreateTransactionContext(fixture, bucketName);
+        var tracked = new AwsTransactionalEntity { Id = id, Name = "tx-update", ETag = original.ETag };
+        context.Attach(tracked);
+        context.Entry(tracked).Property(x => x.ETag).OriginalValue = original.ETag;
+        context.Entry(tracked).State = EntityState.Modified;
+
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+
+        await provider.SaveAsync(path, new AwsTransactionalEntity { Id = id, Name = "v2" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => transaction.CommitAsync());
+    }
+
+    [Fact]
+    public async Task TransactionalCommit_WithStaleEtagOnDelete_ShouldThrowDbUpdateConcurrencyException()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, bucketName) = await CreateIsolatedProviderAsync(fixture, "delete");
+        var id = $"tx-delete-{Guid.NewGuid():N}";
+        var path = new BlobPathResolver(provider).GetPath(typeof(AwsTransactionalEntity), id);
+
+        await provider.SaveAsync(path, new AwsTransactionalEntity { Id = id, Name = "v1" });
+        var original = await provider.ReadWithMetadataAsync<AwsTransactionalEntity>(path);
+
+        await using var context = CreateTransactionContext(fixture, bucketName);
+        var tracked = new AwsTransactionalEntity { Id = id, Name = "to-delete", ETag = original.ETag };
+        context.Attach(tracked);
+        context.Entry(tracked).Property(x => x.ETag).OriginalValue = original.ETag;
+        context.Remove(tracked);
+
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+
+        await provider.SaveAsync(path, new AwsTransactionalEntity { Id = id, Name = "v2" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => transaction.CommitAsync());
+    }
+
+    private static AwsTransactionalTestDbContext CreateTransactionContext(LocalStackFixture fixture, string bucketName)
+    {
+        var options = new DbContextOptionsBuilder<AwsTransactionalTestDbContext>()
+            .UseCloudStorageOrm(cfg =>
+            {
+                cfg.Provider = CloudProvider.Aws;
+                cfg.ContainerName = bucketName;
+                cfg.Aws = new CloudStorageAwsOptions
+                {
+                    AccessKeyId = fixture.AccessKeyId,
+                    SecretAccessKey = fixture.SecretAccessKey,
+                    Region = fixture.Region,
+                    ServiceUrl = fixture.ServiceUrl,
+                    ForcePathStyle = true
+                };
+            })
+            .Options;
+
+        return new AwsTransactionalTestDbContext(options);
+    }
+
+    private static async Task<(AwsS3StorageProvider Provider, string BucketName)> CreateIsolatedProviderAsync(
+        LocalStackFixture fixture,
+        string scenario)
+    {
+        var rawBucketName = $"tx-{scenario}-{Guid.NewGuid():N}";
+        var bucketName = rawBucketName.Length <= 45 ? rawBucketName : rawBucketName[..45];
+        var options = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Aws,
+            ContainerName = bucketName,
+            Aws = new CloudStorageAwsOptions
+            {
+                AccessKeyId = fixture.AccessKeyId,
+                SecretAccessKey = fixture.SecretAccessKey,
+                Region = fixture.Region,
+                ServiceUrl = fixture.ServiceUrl,
+                ForcePathStyle = true
+            }
+        };
+
+        var provider = new AwsS3StorageProvider(options);
+        await provider.CreateContainerIfNotExistsAsync();
+        return (provider, bucketName);
+    }
+
     private static string BuildPath(string scenario)
     {
         return $"test-folder/{scenario}-{Guid.NewGuid():N}.json";
@@ -81,5 +186,27 @@ public class AwsS3StorageProviderTests(LocalStackFixture fixture) : IClassFixtur
     {
         public string Id { get; init; } = string.Empty;
         public string Name { get; init; } = string.Empty;
+    }
+
+    private sealed class AwsTransactionalEntity
+    {
+        [MaxLength(100)]
+        public string Id { get; init; } = string.Empty;
+
+        [MaxLength(100)]
+        public string Name { get; set; } = string.Empty;
+
+        [MaxLength(256)]
+        public string? ETag { get; set; }
+    }
+
+    private sealed class AwsTransactionalTestDbContext(DbContextOptions<AwsTransactionalTestDbContext> options)
+        : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<AwsTransactionalEntity>().HasKey(x => x.Id);
+            modelBuilder.Entity<AwsTransactionalEntity>().UseObjectETagConcurrency();
+        }
     }
 }

--- a/tests/CloudStorageORM.IntegrationTests/Azure/StorageProviders/AzureBlobStorageProviderTests.cs
+++ b/tests/CloudStorageORM.IntegrationTests/Azure/StorageProviders/AzureBlobStorageProviderTests.cs
@@ -1,4 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+using CloudStorageORM.Enums;
+using CloudStorageORM.Extensions;
+using CloudStorageORM.Infrastructure;
+using CloudStorageORM.Options;
 using CloudStorageORM.Providers.Azure.StorageProviders;
+using Microsoft.EntityFrameworkCore;
 using Shouldly;
 
 namespace CloudStorageORM.IntegrationTests.Azure.Azure.StorageProviders;
@@ -70,10 +76,111 @@ public class AzureBlobStorageProviderTests(StorageFixture fixture) : IClassFixtu
 
         ex.Message.ShouldContain("changed by another writer");
     }
+
+    [Fact]
+    public async Task TransactionalCommit_WithStaleEtagOnSave_ShouldThrowDbUpdateConcurrencyException()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, containerName) = await CreateIsolatedProviderAsync(fixture, "save");
+        var id = $"tx-save-{Guid.NewGuid():N}";
+        var path = new BlobPathResolver(provider).GetPath(typeof(TransactionTestEntity), id);
+
+        await provider.SaveAsync(path, new TransactionTestEntity { Id = id, Name = "v1" });
+        var original = await provider.ReadWithMetadataAsync<TransactionTestEntity>(path);
+
+        await using var context = CreateTransactionContext(fixture.ConnectionString, containerName);
+        var tracked = new TransactionTestEntity { Id = id, Name = "tx-update", ETag = original.ETag };
+        context.Attach(tracked);
+        context.Entry(tracked).Property(x => x.ETag).OriginalValue = original.ETag;
+        context.Entry(tracked).State = EntityState.Modified;
+
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+
+        await provider.SaveAsync(path, new TransactionTestEntity { Id = id, Name = "v2" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => transaction.CommitAsync());
+    }
+
+    [Fact]
+    public async Task TransactionalCommit_WithStaleEtagOnDelete_ShouldThrowDbUpdateConcurrencyException()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, containerName) = await CreateIsolatedProviderAsync(fixture, "delete");
+        var id = $"tx-delete-{Guid.NewGuid():N}";
+        var path = new BlobPathResolver(provider).GetPath(typeof(TransactionTestEntity), id);
+
+        await provider.SaveAsync(path, new TransactionTestEntity { Id = id, Name = "v1" });
+        var original = await provider.ReadWithMetadataAsync<TransactionTestEntity>(path);
+
+        await using var context = CreateTransactionContext(fixture.ConnectionString, containerName);
+        var tracked = new TransactionTestEntity { Id = id, Name = "to-delete", ETag = original.ETag };
+        context.Attach(tracked);
+        context.Entry(tracked).Property(x => x.ETag).OriginalValue = original.ETag;
+        context.Remove(tracked);
+
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+
+        await provider.SaveAsync(path, new TransactionTestEntity { Id = id, Name = "v2" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => transaction.CommitAsync());
+    }
+
+    private static AzureTransactionalTestDbContext CreateTransactionContext(string connectionString, string containerName)
+    {
+        var options = new DbContextOptionsBuilder<AzureTransactionalTestDbContext>()
+            .UseCloudStorageOrm(cfg =>
+            {
+                cfg.Provider = CloudProvider.Azure;
+                cfg.ContainerName = containerName;
+                cfg.Azure = new CloudStorageAzureOptions
+                {
+                    ConnectionString = connectionString
+                };
+            })
+            .Options;
+
+        return new AzureTransactionalTestDbContext(options);
+    }
+
+    private static async Task<(AzureBlobStorageProvider Provider, string ContainerName)> CreateIsolatedProviderAsync(
+        StorageFixture fixture,
+        string scenario)
+    {
+        var containerName = $"tx-{scenario}-{Guid.NewGuid():N}"[..30];
+        var provider = new AzureBlobStorageProvider(fixture.ConnectionString, containerName);
+        await provider.CreateContainerIfNotExistsAsync();
+        return (provider, containerName);
+    }
 }
 
 public class TestEntity
 {
     public string Id { get; init; } = string.Empty;
     public string Name { get; init; } = string.Empty;
+}
+
+public sealed class AzureTransactionalTestDbContext(DbContextOptions<AzureTransactionalTestDbContext> options)
+    : DbContext(options)
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TransactionTestEntity>().HasKey(x => x.Id);
+        modelBuilder.Entity<TransactionTestEntity>().UseObjectETagConcurrency();
+    }
+}
+
+public sealed class TransactionTestEntity
+{
+    [MaxLength(100)]
+    public string Id { get; init; } = string.Empty;
+
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(256)]
+    public string? ETag { get; set; }
 }

--- a/tests/CloudStorageORM.Tests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
+++ b/tests/CloudStorageORM.Tests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
@@ -179,6 +179,8 @@ public class AwsS3StorageProviderTests
         s3Mock.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), It.IsAny<CancellationToken>()))
             .Callback<DeleteObjectRequest, CancellationToken>((request, _) => capturedRequest = request)
             .ReturnsAsync(new DeleteObjectResponse());
+        s3Mock.Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetObjectMetadataResponse { ETag = "etag-3" });
 
         var sut = CreateSut(s3Mock);
         await sut.DeleteAsync("users/id-3.json", "etag-3");

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransactionManagerTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransactionManagerTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using CloudStorageORM.Abstractions;
 using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
+using Microsoft.EntityFrameworkCore;
 using Shouldly;
 
 namespace CloudStorageORM.Tests.Infrastructure;
@@ -212,7 +213,7 @@ public class CloudStorageTransactionManagerDurabilityTests
         const string userPath = "users/tx-stage2.json";
         var user = new TransactionTestEntity { Id = "tx-stage2", Name = "Stage 2" };
 
-        await manager.StageSaveOperationAsync(userPath, user, CancellationToken.None);
+        await manager.StageSaveOperationAsync(userPath, user, null, CancellationToken.None);
         await tx.CommitAsync();
 
         var persisted = await storage.ReadAsync<TransactionTestEntity>(userPath);
@@ -269,11 +270,11 @@ public class CloudStorageTransactionManagerDurabilityTests
         var manager = new CloudStorageTransactionManager(storage);
 
         var tx1 = await manager.BeginTransactionAsync();
-        await manager.StageDeleteOperationAsync("users/a.json", CancellationToken.None);
+        await manager.StageDeleteOperationAsync("users/a.json", null, CancellationToken.None);
         await tx1.RollbackAsync();
 
         var tx2 = await manager.BeginTransactionAsync();
-        await manager.StageDeleteOperationAsync("users/b.json", CancellationToken.None);
+        await manager.StageDeleteOperationAsync("users/b.json", null, CancellationToken.None);
         await tx2.RollbackAsync();
 
         storage.GetAllKeys().Any(k =>
@@ -284,11 +285,77 @@ public class CloudStorageTransactionManagerDurabilityTests
             .ShouldBeTrue();
     }
 
+    [Fact]
+    public async Task Commit_ReplaysConditionalSaveUsingStagedIfMatchEtag()
+    {
+        var storage = new InMemoryStorageProvider();
+        var manager = new CloudStorageTransactionManager(storage);
+        const string userPath = "users/conditional-save.json";
+
+        await storage.SaveAsync(userPath, new TransactionTestEntity { Id = "seed", Name = "Seed" });
+        var original = await storage.ReadWithMetadataAsync<TransactionTestEntity>(userPath);
+
+        var tx = await manager.BeginTransactionAsync();
+        await manager.StageSaveOperationAsync(
+            userPath,
+            new TransactionTestEntity { Id = "seed", Name = "Updated" },
+            original.ETag,
+            CancellationToken.None);
+
+        await tx.CommitAsync();
+
+        storage.ConditionalSaveRequests.ShouldContain(x =>
+            x.Path == userPath && x.IfMatchETag == original.ETag);
+    }
+
+    [Fact]
+    public async Task Commit_WhenConditionalSaveHasStaleEtag_ThrowsDbUpdateConcurrencyException()
+    {
+        var storage = new InMemoryStorageProvider();
+        var manager = new CloudStorageTransactionManager(storage);
+        const string userPath = "users/stale-save.json";
+
+        await storage.SaveAsync(userPath, new TransactionTestEntity { Id = "stale", Name = "V1" });
+        var original = await storage.ReadWithMetadataAsync<TransactionTestEntity>(userPath);
+
+        var tx = await manager.BeginTransactionAsync();
+        await manager.StageSaveOperationAsync(
+            userPath,
+            new TransactionTestEntity { Id = "stale", Name = "V2" },
+            original.ETag,
+            CancellationToken.None);
+
+        await storage.SaveAsync(userPath, new TransactionTestEntity { Id = "stale", Name = "Concurrent" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => tx.CommitAsync());
+    }
+
+    [Fact]
+    public async Task Commit_WhenConditionalDeleteHasStaleEtag_ThrowsDbUpdateConcurrencyException()
+    {
+        var storage = new InMemoryStorageProvider();
+        var manager = new CloudStorageTransactionManager(storage);
+        const string userPath = "users/stale-delete.json";
+
+        await storage.SaveAsync(userPath, new TransactionTestEntity { Id = "stale-del", Name = "V1" });
+        var original = await storage.ReadWithMetadataAsync<TransactionTestEntity>(userPath);
+
+        var tx = await manager.BeginTransactionAsync();
+        await manager.StageDeleteOperationAsync(userPath, original.ETag, CancellationToken.None);
+
+        await storage.SaveAsync(userPath, new TransactionTestEntity { Id = "stale-del", Name = "Concurrent" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => tx.CommitAsync());
+    }
+
     private sealed class InMemoryStorageProvider : IStorageProvider
     {
         private readonly Lock _sync = new();
         private readonly Dictionary<string, string> _store = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, string> _etags = new(StringComparer.Ordinal);
         private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+
+        public List<(string Path, string? IfMatchETag)> ConditionalSaveRequests { get; } = [];
 
         // ReSharper disable once UnusedMember.Local
         public IEnumerable<string> Keys
@@ -321,6 +388,7 @@ public class CloudStorageTransactionManagerDurabilityTests
             lock (_sync)
             {
                 _store[path] = JsonSerializer.Serialize(entity, _jsonOptions);
+                _etags[path] = CreateNextEtag();
             }
 
             return Task.CompletedTask;
@@ -328,8 +396,22 @@ public class CloudStorageTransactionManagerDurabilityTests
 
         public Task<string?> SaveAsync<T>(string path, T entity, string? ifMatchETag)
         {
-            SaveAsync(path, entity);
-            return Task.FromResult<string?>("in-memory-etag");
+            lock (_sync)
+            {
+                ConditionalSaveRequests.Add((path, ifMatchETag));
+
+                if (!string.IsNullOrWhiteSpace(ifMatchETag)
+                    && (!_etags.TryGetValue(path, out var currentEtag)
+                        || !string.Equals(currentEtag, ifMatchETag, StringComparison.Ordinal)))
+                {
+                    throw new StoragePreconditionFailedException(path);
+                }
+
+                _store[path] = JsonSerializer.Serialize(entity, _jsonOptions);
+                var nextEtag = CreateNextEtag();
+                _etags[path] = nextEtag;
+                return Task.FromResult<string?>(nextEtag);
+            }
         }
 
         public Task<T> ReadAsync<T>(string path)
@@ -349,7 +431,11 @@ public class CloudStorageTransactionManagerDurabilityTests
         {
             var value = await ReadAsync<T>(path);
             var exists = !EqualityComparer<T>.Default.Equals(value, default!);
-            return new StorageObject<T>(value, exists ? "in-memory-etag" : null, exists);
+            lock (_sync)
+            {
+                _etags.TryGetValue(path, out var eTag);
+                return new StorageObject<T>(value, exists ? eTag : null, exists);
+            }
         }
 
         public Task DeleteAsync(string path)
@@ -357,12 +443,29 @@ public class CloudStorageTransactionManagerDurabilityTests
             lock (_sync)
             {
                 _store.Remove(path);
+                _etags.Remove(path);
             }
 
             return Task.CompletedTask;
         }
 
-        public Task DeleteAsync(string path, string? ifMatchETag) => DeleteAsync(path);
+        public Task DeleteAsync(string path, string? ifMatchETag)
+        {
+            lock (_sync)
+            {
+                if (!string.IsNullOrWhiteSpace(ifMatchETag)
+                    && (!_etags.TryGetValue(path, out var currentEtag)
+                        || !string.Equals(currentEtag, ifMatchETag, StringComparison.Ordinal)))
+                {
+                    throw new StoragePreconditionFailedException(path);
+                }
+
+                _store.Remove(path);
+                _etags.Remove(path);
+            }
+
+            return Task.CompletedTask;
+        }
 
         public Task<List<string>> ListAsync(string folderPath)
         {
@@ -413,6 +516,7 @@ public class CloudStorageTransactionManagerDurabilityTests
             lock (_sync)
             {
                 _store[path] = json;
+                _etags[path] = CreateNextEtag();
             }
 
             return Task.CompletedTask;
@@ -433,6 +537,8 @@ public class CloudStorageTransactionManagerDurabilityTests
                 return _store.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray();
             }
         }
+
+        private static string CreateNextEtag() => $"in-memory-etag-{Guid.NewGuid():N}";
     }
 
     private sealed class TransactionTestEntity


### PR DESCRIPTION
# Pull Request

## 📋 Description
This PR completes **P0-01: Preserve ETag preconditions in staged transactions** and includes related release/documentation updates.

### What changed

#### Transaction correctness (P0-01)
- Added `ifMatchETag` support to staged durable operations in `src/CloudStorageORM/Infrastructure/CloudStorageTransactionManager.cs`.
- Forwarded original ETag values when staging transactional save/delete operations from `src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs`.
- Replayed staged durable operations using conditional provider calls (`If-Match`) in `CloudStorageTransactionManager`.
- Mapped provider precondition failures during transactional replay to `DbUpdateConcurrencyException`.

#### Reliability and provider parity adjustments
- Updated `src/CloudStorageORM/Infrastructure/CloudStorageDbContextTransaction.cs` so transaction completion state is finalized safely even when commit/rollback throws.
- Hardened AWS conditional delete behavior in `src/CloudStorageORM/Providers/Aws/StorageProviders/AwsS3StorageProvider.cs` to preserve optimistic concurrency semantics consistently.

#### Tests
- Extended `tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransactionManagerTests.cs` with conditional replay + stale-ETag conflict coverage.
- Added Azure stale-ETag transactional commit integration coverage in `tests/CloudStorageORM.IntegrationTests/Azure/StorageProviders/AzureBlobStorageProviderTests.cs`.
- Added AWS stale-ETag transactional commit integration coverage in `tests/CloudStorageORM.IntegrationTests/Aws/StorageProviders/AwsS3StorageProviderTests.cs`.
- Updated AWS provider unit test expectations in `tests/CloudStorageORM.Tests/Aws/StorageProviders/AwsS3StorageProviderTests.cs`.

#### Docs and release metadata
- Updated transaction/concurrency docs:
  - `docs/transactions.md`
  - `docs/concurrency.md`
- Added Dependabot documentation updates:
  - `docs/ci.md`
  - `CONTRIBUTING.md`
- Enabled Dependabot:
  - `.github/dependabot.yml` (`nuget` + `github-actions`, weekly schedule)
- Advanced release line to `1.0.14`:
  - `src/CloudStorageORM/CloudStorageORM.csproj`
  - `README.md`
  - `docs/CloudStorageORM.md`
  - `ROADMAP.md`
- Updated backlog tracking:
  - `TODO-LIST` (removed completed `P0-01`, milestone range adjusted)

## 🔎 Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [x] Other (please specify): Release/versioning updates and Dependabot enablement

## 🧪 How to test

### 1) Transaction manager unit tests
```bash
dotnet test tests/CloudStorageORM.Tests/CloudStorageORM.Tests.csproj --filter "FullyQualifiedName~CloudStorageTransactionManagerDurabilityTests"
```

### 2) Azure transactional stale-ETag integration tests
```bash
dotnet test tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj --filter "FullyQualifiedName~TransactionalCommit_WithStaleEtag"
```

### 3) AWS transactional stale-ETag integration tests
```bash
dotnet test tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.AWS.csproj --filter "FullyQualifiedName~TransactionalCommit_WithStaleEtag"
```

### 4) SampleApp integration lane (requires Azurite + LocalStack)
```bash
docker rm -f azurite localstack || true
docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 --name azurite mcr.microsoft.com/azure-storage/azurite
docker run -d -p 4566:4566 -e SERVICES=s3 -e AWS_DEFAULT_REGION=us-east-1 --name localstack localstack/localstack:3
dotnet test tests/CloudStorageORM.IntegrationTests.SampleApp/CloudStorageORM.IntegrationTests.SampleApp.csproj --nologo -v minimal
```

## 📚 Checklist  
- [x] Code follows project standards  
- [x] Tests were added or updated  
- [x] Documentation was updated if necessary  
- [x] Build and tests are passing 