### PR TITLE
feat: add configurable transient-fault retry strategy with bounded ex…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Support for **Google Cloud Storage** remains on the roadmap.
 
 ## ✨ Current status
 
-- ✅ Current release line: `v1.0.15`
+- ✅ Current release line: `v1.0.16`
 - ✅ Targets `net10.0`
 - ✅ Azure Blob Storage provider is implemented
 - ✅ AWS S3 provider is implemented
@@ -29,6 +29,9 @@ Support for **Google Cloud Storage** remains on the roadmap.
 - ✅ Sample app runs the same CRUD flow against EF InMemory, Azure, and AWS
 - ✅ Unit + integration tests run locally with Azurite and LocalStack
 - ✅ Coverage collection is wired with Coverlet + ReportGenerator
+- ✅ `v1.0.16` adds configurable transient-fault retries (bounded exponential backoff + jitter) at shared persistence/query execution boundaries
+- ✅ `v1.0.16` completes runtime logging/tracing wiring across save/query/transaction/recovery paths
+- ✅ `v1.0.16` Azure and AWS integration suites cover rollback, commit, crash-recovery, and stale-ETag conflict windows
 - ✅ `v1.0.15` implements crash-safe, idempotent transaction replay with operation-level progress tracking
 - ✅ `v1.0.14` preserves `If-Match` ETag preconditions for staged transaction save/delete replay and surfaces conflicts
   as `DbUpdateConcurrencyException`
@@ -152,6 +155,8 @@ await db.SaveChangesAsync();
   this interface is not required.
 - When ETag concurrency is enabled, updates/deletes use provider-native `If-Match` conditions (Azure Blob and AWS S3)
   and conflicts are raised as `DbUpdateConcurrencyException`.
+- Transient retries are optional and configured under `storage.Retry` (`Enabled`, `MaxRetries`, `BaseDelay`,
+  `MaxDelay`, `JitterFactor`).
 - Future versions may add provider-native temporary locking (for example, Azure blob leases and AWS
   conditional/object-lock strategies) to improve concurrent-writer coordination.
 - `IDatabaseCreator` behavior is still minimal right now: schema-style database lifecycle methods are not fully

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,18 +6,31 @@ This document outlines the evolution of CloudStorageORM from the current release
 
 ## ✅ Current released version
 
-### v1.0.14
+### v1.0.16
 
-- Version bump to `1.0.14` for the current release line.
-- Preserve staged transaction `If-Match` ETag preconditions during commit replay for update/delete operations.
-- Surface stale-ETag transactional commit conflicts as `DbUpdateConcurrencyException`.
-- Add Azure and AWS integration coverage for stale-ETag transactional commit scenarios.
-- Enable Dependabot automation for NuGet and GitHub Actions updates through `.github/dependabot.yml`.
-
+- Version bump to `1.0.16` for the current release line.
+- Add configurable transient-fault retries with bounded exponential backoff and jitter in shared persistence/query
+  paths.
+- Keep provider-specific behavior unchanged while centralizing retry behavior at shared execution boundaries.
+- Add unit and integration coverage for recoverable transient failures and retry budget behavior.
 
 ---
 
 ## 📋 Previous releases
+
+### v1.0.15
+
+- Version bump to `1.0.15` for the previous release line.
+- Transaction replay is now crash-safe and idempotent with operation-level progress tracking.
+- Interrupted commits can safely resume from the last applied operation without duplicating side effects.
+
+### v1.0.14
+
+- Version bump to `1.0.14` for the previous release line.
+- Preserve staged transaction `If-Match` ETag preconditions during commit replay for update/delete operations.
+- Surface stale-ETag transactional commit conflicts as `DbUpdateConcurrencyException`.
+- Add Azure and AWS integration coverage for stale-ETag transactional commit scenarios.
+- Enable Dependabot automation for NuGet and GitHub Actions updates through `.github/dependabot.yml`.
 
 ### v1.0.13
 
@@ -26,20 +39,24 @@ This document outlines the evolution of CloudStorageORM from the current release
 - Server-side `Skip`/`Take` pushdown for supported query shapes
 - Observability improvements and refreshed guidance for logging, tracing, and diagnostics options
 - ETag-based optimistic concurrency support to CloudStorageORM:
-  - Introduces StorageObject<T> to encapsulate the stored value, ETag, and existence state, and adds IETag for entities that optionally expose an ETag property.
-  - The storage pipeline now supports SaveAsync and DeleteAsync operations with ETag conditions, and both Azure Blob Storage and AWS S3 providers have been updated to enforce concurrency checks.
-  - Model configuration has also been updated so entities can be configured for ETag concurrency, and tests were added to cover the new concurrency scenarios.
-
+    - Introduces StorageObject<T> to encapsulate the stored value, ETag, and existence state, and adds IETag for
+      entities that optionally expose an ETag property.
+    - The storage pipeline now supports SaveAsync and DeleteAsync operations with ETag conditions, and both Azure Blob
+      Storage and AWS S3 providers have been updated to enforce concurrency checks.
+    - Model configuration has also been updated so entities can be configured for ETag concurrency, and tests were added
+      to cover the new concurrency scenarios.
 
 ### v1.0.12
 
 - Version bump to `1.0.12` for the previous release line
 - Documentation refreshed to keep local test guidance aligned with CI emulator setup
 - ETag-based optimistic concurrency support to CloudStorageORM:
-  - Introduces StorageObject<T> to encapsulate the stored value, ETag, and existence state, and adds IETag for entities that optionally expose an ETag property.
-  - The storage pipeline now supports SaveAsync and DeleteAsync operations with ETag conditions, and both Azure Blob Storage and AWS S3 providers have been updated to enforce concurrency checks.
-  - Model configuration has also been updated so entities can be configured for ETag concurrency, and tests were added to cover the new concurrency scenarios.
-
+    - Introduces StorageObject<T> to encapsulate the stored value, ETag, and existence state, and adds IETag for
+      entities that optionally expose an ETag property.
+    - The storage pipeline now supports SaveAsync and DeleteAsync operations with ETag conditions, and both Azure Blob
+      Storage and AWS S3 providers have been updated to enforce concurrency checks.
+    - Model configuration has also been updated so entities can be configured for ETag concurrency, and tests were added
+      to cover the new concurrency scenarios.
 
 ### v1.0.11
 
@@ -62,7 +79,6 @@ This document outlines the evolution of CloudStorageORM from the current release
 - Keep roadmap, CI workflows, and package metadata aligned with the current release line
 - Preserve sample app parity between EF InMemory and CloudStorageORM providers
 - Maintain HTML coverage reporting workflow and contributor guidance
-
 
 ### v1.0.10
 
@@ -137,4 +153,5 @@ This document outlines the evolution of CloudStorageORM from the current release
 
 ---
 
-> CloudStorageORM is evolving toward a practical EF-style experience over object storage, starting with Azure and expanding provider support over time.
+> CloudStorageORM is evolving toward a practical EF-style experience over object storage, starting with Azure and
+> expanding provider support over time.

--- a/TODO-LIST
+++ b/TODO-LIST
@@ -15,49 +15,6 @@ Backlog policy
 
 ---
 
-P0 - Correctness and recoverability (must complete before new provider expansion)
-
-Issue P0-03
-Title: Add transient-fault retry strategy for provider I/O
-Scope:
-- Introduce bounded retry policy with jitter for transient provider failures in persistence/query paths (`src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs`, `src/CloudStorageORM/Infrastructure/CloudStorageQueryProvider.cs`).
-- Keep provider-specific behavior unchanged; apply retries at shared execution boundary.
-- Document retry configuration and caveats (`docs/configuration.md`, `docs/troubleshooting.md`).
-Acceptance Criteria:
-- [ ] Retry strategy is configurable and disabled/enabled explicitly by options.
-- [ ] Non-transient errors are not retried.
-- [ ] Transient failure paths succeed within configured retry budget when recoverable.
-Test Checklist:
-- [ ] Unit tests for classification and retry limits.
-- [ ] Integration tests against Azurite/LocalStack with induced transient errors where feasible.
-
-Issue P0-04
-Title: Complete runtime observability wiring
-Scope:
-- Emit currently missing logs/events across save/query/transaction/recovery paths (`src/CloudStorageORM/Observability/CloudStorageOrmLoggingExtensions.cs`, `src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs`, `src/CloudStorageORM/Infrastructure/CloudStorageQueryProvider.cs`, `src/CloudStorageORM/Infrastructure/CloudStorageTransactionManager.cs`).
-- Align docs with actual behavior, including `EnableDiagnostics` status (`docs/observability.md`).
-Acceptance Criteria:
-- [ ] Event IDs defined in `CloudStorageOrmEventIds` are emitted by real runtime paths or removed with rationale.
-- [ ] Tracing/logging toggles behave as documented.
-- [ ] Observability docs match actual implementation.
-Test Checklist:
-- [ ] Extend observability unit tests (`tests/CloudStorageORM.Tests/Observability/**`).
-- [ ] Add integration assertions for key transaction and concurrency log events.
-
-Issue P0-05
-Title: Add transaction/concurrency failure-window integration coverage
-Scope:
-- Add CI-stable integration scenarios for rollback, commit, crash-recovery, and stale-ETag conflicts (`tests/CloudStorageORM.IntegrationTests/**`).
-- Update local run docs for any new prerequisites (`docs/testing-with-azurite.md`, `docs/testing-with-localstack.md`).
-Acceptance Criteria:
-- [ ] CI passes deterministic transaction correctness scenarios on Azure and AWS emulators.
-- [ ] Coverage includes both success and failure windows.
-Test Checklist:
-- [ ] Add dedicated test classes for transaction recovery and cross-writer conflicts.
-- [ ] Validate compatibility with `.github/workflows/ci.yml` execution model.
-
----
-
 P1 - Security, auditability, and operational confidence
 
 Issue P1-01
@@ -189,7 +146,7 @@ Test Checklist:
 
 Execution tracking
 - [ ] Create epic: "Enterprise Readiness".
-- [ ] Milestone A: Transaction correctness and recovery (P0-02..P0-05).
+- [ ] Milestone A: Transaction correctness and recovery.
 - [ ] Milestone B: Security, observability, auditability (P1-01..P1-05).
 - [ ] Milestone C: Platform maturity and operations (P2-01..P2-04).
 

--- a/docs/CloudStorageORM.md
+++ b/docs/CloudStorageORM.md
@@ -1,7 +1,7 @@
 # 📦 CloudStorageORM - Library Documentation
 
 **Target Framework**: `net10.0`  
-**Current Release**: `v1.0.15`  
+**Current Release**: `v1.0.16`
 **Language Version**: `C# 14`  
 **EF Core Packages**: `Microsoft.EntityFrameworkCore 10.0.5`, `Microsoft.EntityFrameworkCore.Relational 10.0.5`  
 **Testing**: `xUnit`, `Shouldly`, `Moq`, `Coverlet`, `ReportGenerator`
@@ -21,6 +21,14 @@ The current branch is focused on:
 - LINQ query execution over persisted blobs
 - CRUD flows that behave similarly to the EF InMemory provider for the sample app
 - Unit and integration test coverage around infrastructure, queries, validators, and provider behavior
+
+## Release notes for `v1.0.16`
+
+- Added configurable transient-fault retries for shared persistence/query provider I/O boundaries.
+- Retries now use bounded exponential backoff with jitter and explicit opt-in via `CloudStorageOptions.Retry`.
+- Non-transient failures (including ETag concurrency conflicts) are intentionally not retried.
+- Runtime logging/tracing now covers shared save, query, transaction, and recovery paths.
+- Azure and AWS integration suites now cover rollback, commit, crash-recovery, and stale-ETag conflict windows.
 
 ## Release notes for `v1.0.15`
 
@@ -73,6 +81,7 @@ Configuration model on the current branch:
 - Common fields: `CloudStorageOptions.Provider`, `CloudStorageOptions.ContainerName`
 - Azure fields: `CloudStorageOptions.Azure.ConnectionString`
 - AWS fields: `CloudStorageOptions.Aws.AccessKeyId`, `SecretAccessKey`, `Region`, `ServiceUrl`, `ForcePathStyle`
+- Retry fields: `CloudStorageOptions.Retry.Enabled`, `MaxRetries`, `BaseDelay`, `MaxDelay`, `JitterFactor`
 - Observability fields: `CloudStorageOptions.Observability.EnableLogging`, `EnableTracing`, `EnableDiagnostics`
 - `CloudStorageOptions.ConnectionString` at the root level is no longer used
 
@@ -129,8 +138,8 @@ CloudStorageORM observability is configured through `CloudStorageOptions.Observa
 
 - `EnableLogging` gates logging inside persistence and query paths.
 - `EnableTracing` gates `ActivitySource` spans emitted by internal operations.
-- `EnableDiagnostics` is currently surfaced as configuration/debug metadata and reserved for future custom diagnostics
-  events.
+- `EnableDiagnostics` is currently surfaced as configuration/debug metadata; custom runtime `DiagnosticListener`
+  events are not emitted yet.
 
 Related types:
 
@@ -239,6 +248,8 @@ The repository currently includes:
   `tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj`
 - LocalStack-backed AWS integration tests in
   `tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.AWS.csproj`
+- dedicated Azure and AWS transaction failure-window suites covering rollback, commit, crash recovery, and stale-ETag
+  conflicts
 - Sample app integration tests in
   `tests/CloudStorageORM.IntegrationTests.SampleApp/CloudStorageORM.IntegrationTests.SampleApp.csproj`
 - coverage collection through `coverlet.collector` / `coverlet.msbuild`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,21 +81,22 @@ CloudStorageORM validates the configuration at context initialization. Common er
 
 ## Observability configuration (optional)
 
-CloudStorageORM can emit structured logs, tracing spans, and diagnostics hooks. All are enabled by default and can be
-controlled under `CloudStorageOptions.Observability`.
+CloudStorageORM can emit structured logs and tracing spans from its shared runtime boundaries. Those are enabled by
+default and can be controlled under `CloudStorageOptions.Observability`.
 
 Current behavior on `main`:
 
 - `EnableLogging` controls CloudStorageORM `ILogger` events.
 - `EnableTracing` controls CloudStorageORM `ActivitySource` span creation.
-- `EnableDiagnostics` is part of options/debug info; custom runtime `DiagnosticListener` events are not emitted yet.
+- `EnableDiagnostics` is currently part of options/debug info; custom runtime `DiagnosticListener` events are not
+  emitted yet.
 
 ```csharp
 storage.Observability.EnableLogging = true;
 storage.Observability.EnableTracing = true;
 storage.Observability.EnableDiagnostics = true;
 
-// Optional custom names (reserved for future custom-source wiring)
+// Optional custom names (currently surfaced in options/debug info)
 storage.Observability.ActivitySourceName = "CloudStorageORM";
 storage.Observability.DiagnosticListenerName = "CloudStorageORM";
 ```
@@ -103,6 +104,31 @@ storage.Observability.DiagnosticListenerName = "CloudStorageORM";
 If your application does not consume these signals, you can disable them individually.
 
 See [Observability guide](observability.md) for practical usage profiles and consumer examples.
+
+## Retry configuration (optional)
+
+CloudStorageORM can apply a bounded retry strategy with exponential backoff and jitter for transient provider I/O
+failures in shared persistence/query execution paths.
+
+- Retries are **disabled by default** and must be enabled explicitly.
+- Non-transient exceptions (including concurrency conflicts) are not retried.
+- Retries are applied at the shared persistence/query execution boundary rather than inside provider-specific code.
+- Retry policy is configured at `CloudStorageOptions.Retry`.
+
+```csharp
+storage.Retry.Enabled = true;
+storage.Retry.MaxRetries = 3; // retries after the initial attempt
+storage.Retry.BaseDelay = TimeSpan.FromMilliseconds(100);
+storage.Retry.MaxDelay = TimeSpan.FromSeconds(2);
+storage.Retry.JitterFactor = 0.2;
+```
+
+### Retry option notes
+
+- `Enabled`: explicit opt-in gate.
+- `MaxRetries`: number of retries after the initial attempt (`0` means no retries).
+- `BaseDelay` / `MaxDelay`: exponential backoff lower/upper bounds.
+- `JitterFactor`: randomization amount in range `[0, 1]` to reduce coordinated retry bursts.
 
 ## Model configuration
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,14 +2,9 @@
 
 CloudStorageORM includes optional observability controls under `CloudStorageOptions.Observability`.
 
-## v1.0.13 release note
-
-The `v1.0.13` release keeps the same observability switches, but the documentation now highlights the
-logging, tracing, and diagnostics surface alongside the new server-side `Skip`/`Take` query support.
-
 ## Current capability on `main`
 
-- `EnableLogging` controls provider query/save log emission from CloudStorageORM internals.
+- `EnableLogging` controls runtime `ILogger` emission from shared save/query/transaction/recovery paths.
 - `EnableTracing` controls `ActivitySource` spans created by CloudStorageORM internals.
 - `EnableDiagnostics` is part of the public options model and EF debug info, but there are currently no custom
   `DiagnosticListener` events emitted yet.
@@ -38,7 +33,7 @@ services.AddDbContext<AppDbContext>(options =>
         storage.Observability.EnableTracing = true;
         storage.Observability.EnableDiagnostics = true;
 
-        // Reserved naming options (currently not used by runtime emission)
+        // Naming options are currently surfaced in options/debug info.
         storage.Observability.ActivitySourceName = "CloudStorageORM";
         storage.Observability.DiagnosticListenerName = "CloudStorageORM";
     });
@@ -110,6 +105,13 @@ CloudStorageORM event IDs are grouped by category in `CloudStorageOrmEventIds`:
 - Concurrency (`500x`)
 - Provider I/O (`600x`)
 - Validation (`700x`)
+
+Runtime paths currently emitting these event groups include:
+
+- `CloudStorageDatabase` save and materialization/listing boundaries
+- `CloudStorageQueryProvider` query execution boundaries
+- `CloudStorageTransactionManager` begin/commit/rollback/recovery and durable replay paths
+- `CloudStorageDbContext` configuration/validation initialization boundaries
 
 ## Related docs
 

--- a/docs/testing-with-azurite.md
+++ b/docs/testing-with-azurite.md
@@ -70,7 +70,8 @@ This runs:
 - unit tests in `tests/CloudStorageORM.Tests`
 - Azure integration tests in `tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj`
 - AWS integration tests in `tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.AWS.csproj`
-- SampleApp integration tests in `tests/CloudStorageORM.IntegrationTests.SampleApp/CloudStorageORM.IntegrationTests.SampleApp.csproj`
+- SampleApp integration tests in
+  `tests/CloudStorageORM.IntegrationTests.SampleApp/CloudStorageORM.IntegrationTests.SampleApp.csproj`
 
 For CI-style TRX and coverage artifact layout, see [ci.md](./ci.md).
 
@@ -83,6 +84,15 @@ If Azurite is unavailable, Azure-backed integration scenarios are skipped by fix
 ```bash
 dotnet test tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj --nologo -v minimal
 ```
+
+To focus only on the Azure transaction failure-window suite (`AzureTransactionFailureWindowTests`), which covers
+rollback, commit, committed-manifest recovery, and stale-ETag conflict cases:
+
+```bash
+dotnet test tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj --nologo -v minimal --filter "FullyQualifiedName~AzureTransactionFailureWindowTests"
+```
+
+The suite also asserts the transaction and concurrency log events emitted by the runtime path.
 
 ---
 
@@ -168,6 +178,7 @@ dotnet test tests/CloudStorageORM.Tests/CloudStorageORM.Tests.csproj --nologo -v
 - `tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj`
 - `tests/CloudStorageORM.IntegrationTests/Azure/StorageFixture.cs`
 - `tests/CloudStorageORM.IntegrationTests/Azure/StorageProviders/AzureBlobStorageProviderTests.cs`
+- `tests/CloudStorageORM.IntegrationTests/Azure/Transactions/AzureTransactionFailureWindowTests.cs`
 - `coverlet.runsettings`
 - `dotnet-tools.json`
 

--- a/docs/testing-with-localstack.md
+++ b/docs/testing-with-localstack.md
@@ -51,6 +51,15 @@ These defaults are used by tests/sample if variables are not set:
 dotnet test tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.AWS.csproj --nologo -v minimal
 ```
 
+To focus only on the AWS transaction failure-window suite (`AwsTransactionFailureWindowTests`), which covers rollback,
+commit, committed-manifest recovery, and stale-ETag conflict cases:
+
+```bash
+dotnet test tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.AWS.csproj --nologo -v minimal --filter "FullyQualifiedName~AwsTransactionFailureWindowTests"
+```
+
+The suite also asserts the transaction and concurrency log events emitted by the runtime path.
+
 If LocalStack is unavailable, AWS integration scenarios are skipped by fixture guards.
 
 ---
@@ -103,4 +112,5 @@ export CLOUDSTORAGEORM_AWS_FORCE_PATH_STYLE=true
 - `tests/CloudStorageORM.IntegrationTests.SampleApp/CloudStorageORM.IntegrationTests.SampleApp.csproj`
 - `tests/CloudStorageORM.IntegrationTests/Aws/LocalStackFixture.cs`
 - `tests/CloudStorageORM.IntegrationTests/Aws/StorageProviders/AwsS3StorageProviderTests.cs`
+- `tests/CloudStorageORM.IntegrationTests/Aws/Transactions/AwsTransactionFailureWindowTests.cs`
 - `tests/CloudStorageORM.IntegrationTests.SampleApp/ProgramExitAwsSampleAppTests.cs`

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -112,6 +112,9 @@ On startup of a new transaction manager instance:
 
 Recovery is deterministic and idempotent—running it multiple times produces the same result.
 
+The rollback, commit, crash-recovery, and stale-ETag conflict windows described above are covered by the dedicated
+Azure and AWS integration suites `AzureTransactionFailureWindowTests` and `AwsTransactionFailureWindowTests`.
+
 ## Example: Transaction with retry
 
 ```csharp

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,6 +35,28 @@ docker run -d -p 4566:4566 \
 aws s3 ls --endpoint-url=http://127.0.0.1:4566
 ```
 
+### Repeated transient network failures
+
+**Symptoms**: intermittent `HttpRequestException`, timeout, or service unavailable responses during save/query
+operations.
+
+**Cause**: temporary network/provider instability and retry policy disabled or under-sized.
+
+**Solution**:
+
+1. Enable retries explicitly under `CloudStorageOptions.Retry`.
+2. Start with conservative values (`MaxRetries = 3`, `BaseDelay = 100ms`, `MaxDelay = 2s`, `JitterFactor = 0.2`).
+3. Increase `MaxRetries` or delay budget only when failures are recoverable and latency budget allows it.
+4. Keep in mind non-transient failures (for example stale ETag concurrency conflicts) are not retried.
+
+```csharp
+storage.Retry.Enabled = true;
+storage.Retry.MaxRetries = 3;
+storage.Retry.BaseDelay = TimeSpan.FromMilliseconds(100);
+storage.Retry.MaxDelay = TimeSpan.FromSeconds(2);
+storage.Retry.JitterFactor = 0.2;
+```
+
 ### Invalid credentials
 
 **Error**: `UnauthorizedAccessException` or `AccessDeniedException`

--- a/src/CloudStorageORM/Abstractions/StorageListPage.cs
+++ b/src/CloudStorageORM/Abstractions/StorageListPage.cs
@@ -3,6 +3,9 @@ namespace CloudStorageORM.Abstractions;
 /// <summary>
 /// Represents a single provider list page with continuation state.
 /// </summary>
+/// <param name="Keys">The object keys returned in this page.</param>
+/// <param name="ContinuationToken">The token that can be used to request the next page, when available.</param>
+/// <param name="HasMore">Indicates whether more pages are available.</param>
 public sealed record StorageListPage(
     IReadOnlyList<string> Keys,
     string? ContinuationToken,

--- a/src/CloudStorageORM/CloudStorageORM.csproj
+++ b/src/CloudStorageORM/CloudStorageORM.csproj
@@ -8,7 +8,7 @@
 
         <!-- NuGet package metadata -->
         <PackageId>CloudStorageORM</PackageId>
-        <Version>1.0.14</Version>
+        <Version>1.0.16</Version>
         <Authors>Rodrigo Zavalik Castro</Authors>
         <PackageReadmeFile>README.md</PackageReadmeFile>
 

--- a/src/CloudStorageORM/Contexts/CloudStorageDbContext.cs
+++ b/src/CloudStorageORM/Contexts/CloudStorageDbContext.cs
@@ -1,9 +1,12 @@
 using CloudStorageORM.Extensions;
 using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
+using CloudStorageORM.Observability;
 using CloudStorageORM.Providers;
 using CloudStorageORM.Validators;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Logging;
 
 namespace CloudStorageORM.Contexts;
 
@@ -13,6 +16,7 @@ namespace CloudStorageORM.Contexts;
 public class CloudStorageDbContext : DbContext
 {
     private readonly IStorageProvider _storageProvider;
+    private readonly bool _enableLogging;
 
     /// <summary>
     /// Creates a CloudStorageORM DbContext from configured EF options.
@@ -41,8 +45,20 @@ public class CloudStorageDbContext : DbContext
                            ?.Options
                        ?? throw new InvalidCastException("Options must be of type CloudStorageOptions.");
 
+        var provider = options1.Provider;
+        var containerName = options1.ContainerName;
+        _enableLogging = options1.Observability.EnableLogging;
+
         _storageProvider = ProviderFactory.GetStorageProvider(options1)
                            ?? throw new ArgumentNullException(nameof(_storageProvider));
+
+        if (!_enableLogging)
+        {
+            return;
+        }
+
+        var logger = TryResolveLogger();
+        logger?.LogConfigurationInitialized(provider.ToString(), containerName);
     }
 
     /// <inheritdoc />
@@ -50,10 +66,31 @@ public class CloudStorageDbContext : DbContext
     {
         base.OnModelCreating(modelBuilder);
 
+        var logger = _enableLogging ? TryResolveLogger() : null;
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
         modelBuilder.ApplyBlobSettingsConventions();
 
         var validator = new CloudStorageModelValidator(_storageProvider);
+        logger?.LogValidationStarting("CloudStorageModel");
 
-        validator.Validate(modelBuilder.Model);
+        try
+        {
+            validator.Validate(modelBuilder.Model);
+            stopwatch.Stop();
+            logger?.LogValidationCompleted("CloudStorageModel", stopwatch.ElapsedMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            logger?.LogValidationFailed("CloudStorageModel", ex.Message, ex);
+            throw;
+        }
+    }
+
+    private ILogger<CloudStorageDbContext>? TryResolveLogger()
+    {
+        return ((IInfrastructure<IServiceProvider>)this).Instance.GetService(typeof(ILogger<CloudStorageDbContext>))
+            as ILogger<CloudStorageDbContext>;
     }
 }

--- a/src/CloudStorageORM/Enums/CloudProvider.cs
+++ b/src/CloudStorageORM/Enums/CloudProvider.cs
@@ -1,8 +1,22 @@
 namespace CloudStorageORM.Enums;
 
+/// <summary>
+/// Supported cloud object-storage providers.
+/// </summary>
 public enum CloudProvider
 {
+    /// <summary>
+    /// Azure Blob Storage.
+    /// </summary>
     Azure,
+
+    /// <summary>
+    /// AWS S3.
+    /// </summary>
     Aws,
+
+    /// <summary>
+    /// Google Cloud Storage (planned, not yet implemented).
+    /// </summary>
     Gcp
 }

--- a/src/CloudStorageORM/Extensions/CloudStorageOrmOptionsExtensionInfo.cs
+++ b/src/CloudStorageORM/Extensions/CloudStorageOrmOptionsExtensionInfo.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using CloudStorageORM.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
@@ -36,14 +37,16 @@ public class CloudStorageOrmOptionsExtensionInfo(CloudStorageOrmOptionsExtension
     public override int GetServiceProviderHashCode()
     {
         var options = Extension.Options;
+        var retry =
+            $"retry:{options.Retry.Enabled}|{options.Retry.MaxRetries}|{options.Retry.BaseDelay.TotalMilliseconds}|{options.Retry.MaxDelay.TotalMilliseconds}|{options.Retry.JitterFactor}";
         var raw = options.Provider switch
         {
             Enums.CloudProvider.Azure =>
-                $"azure|{options.ContainerName}|{options.Azure.ConnectionString}|obs:{options.Observability.EnableLogging}|{options.Observability.EnableTracing}|{options.Observability.EnableDiagnostics}",
+                $"azure|{options.ContainerName}|{options.Azure.ConnectionString}|obs:{options.Observability.EnableLogging}|{options.Observability.EnableTracing}|{options.Observability.EnableDiagnostics}|{retry}",
             Enums.CloudProvider.Aws =>
-                $"aws|{options.ContainerName}|{options.Aws.Region}|{options.Aws.ServiceUrl}|{options.Aws.AccessKeyId}|{options.Aws.SecretAccessKey}|{options.Aws.ForcePathStyle}|obs:{options.Observability.EnableLogging}|{options.Observability.EnableTracing}|{options.Observability.EnableDiagnostics}",
+                $"aws|{options.ContainerName}|{options.Aws.Region}|{options.Aws.ServiceUrl}|{options.Aws.AccessKeyId}|{options.Aws.SecretAccessKey}|{options.Aws.ForcePathStyle}|obs:{options.Observability.EnableLogging}|{options.Observability.EnableTracing}|{options.Observability.EnableDiagnostics}|{retry}",
             _ =>
-                $"{options.Provider}|{options.ContainerName}|obs:{options.Observability.EnableLogging}|{options.Observability.EnableTracing}|{options.Observability.EnableDiagnostics}"
+                $"{options.Provider}|{options.ContainerName}|obs:{options.Observability.EnableLogging}|{options.Observability.EnableTracing}|{options.Observability.EnableDiagnostics}|{retry}"
         };
 
         return StringComparer.Ordinal.GetHashCode(raw);
@@ -66,7 +69,13 @@ public class CloudStorageOrmOptionsExtensionInfo(CloudStorageOrmOptionsExtension
         debugInfo["CloudStorageORM:ContainerName"] = options.ContainerName;
         debugInfo["CloudStorageORM:Observability:EnableLogging"] = options.Observability.EnableLogging.ToString();
         debugInfo["CloudStorageORM:Observability:EnableTracing"] = options.Observability.EnableTracing.ToString();
-        debugInfo["CloudStorageORM:Observability:EnableDiagnostics"] = options.Observability.EnableDiagnostics.ToString();
+        debugInfo["CloudStorageORM:Observability:EnableDiagnostics"] =
+            options.Observability.EnableDiagnostics.ToString();
+        debugInfo["CloudStorageORM:Retry:Enabled"] = options.Retry.Enabled.ToString();
+        debugInfo["CloudStorageORM:Retry:MaxRetries"] = options.Retry.MaxRetries.ToString();
+        debugInfo["CloudStorageORM:Retry:BaseDelayMs"] = options.Retry.BaseDelay.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+        debugInfo["CloudStorageORM:Retry:MaxDelayMs"] = options.Retry.MaxDelay.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+        debugInfo["CloudStorageORM:Retry:JitterFactor"] = options.Retry.JitterFactor.ToString(CultureInfo.InvariantCulture);
 
         switch (options.Provider)
         {
@@ -100,7 +109,8 @@ public class CloudStorageOrmOptionsExtensionInfo(CloudStorageOrmOptionsExtension
         return options.Provider switch
         {
             Enums.CloudProvider.Azure => options.Azure.ConnectionString,
-            Enums.CloudProvider.Aws => $"region={options.Aws.Region};serviceUrl={options.Aws.ServiceUrl};container={options.ContainerName}",
+            Enums.CloudProvider.Aws =>
+                $"region={options.Aws.Region};serviceUrl={options.Aws.ServiceUrl};container={options.ContainerName}",
             _ => options.ContainerName
         };
     }

--- a/src/CloudStorageORM/Infrastructure/BlobPathResolver.cs
+++ b/src/CloudStorageORM/Infrastructure/BlobPathResolver.cs
@@ -6,6 +6,10 @@ using Microsoft.EntityFrameworkCore.Update;
 
 namespace CloudStorageORM.Infrastructure;
 
+/// <summary>
+/// Resolves deterministic blob names and full storage paths for EF entity types.
+/// </summary>
+/// <param name="storageProvider">Provider used to sanitize blob names for the active cloud backend.</param>
 public class BlobPathResolver(IStorageProvider storageProvider) : IBlobPathResolver
 {
     private readonly IStorageProvider _storageProvider = storageProvider

--- a/src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageDatabase.cs
@@ -22,6 +22,16 @@ namespace CloudStorageORM.Infrastructure;
 /// <summary>
 /// IDatabase implementation that persists EF entity changes to object storage.
 /// </summary>
+/// <param name="model">The EF model being persisted.</param>
+/// <param name="databaseCreator">Provider database creator.</param>
+/// <param name="executionStrategyFactory">EF execution strategy factory.</param>
+/// <param name="storageProvider">Cloud storage provider implementation.</param>
+/// <param name="currentDbContext">Accessor for the current DbContext instance.</param>
+/// <param name="blobPathResolver">Resolves entity blob paths.</param>
+/// <param name="transactionManager">Current transaction manager.</param>
+/// <param name="cloudStorageOptions">CloudStorageORM options controlling retries and observability.</param>
+/// <param name="loggerFactory">Factory used for category-specific loggers.</param>
+/// <param name="logger">Logger for database-level events.</param>
 public class CloudStorageDatabase(
     IModel model,
     IDatabaseCreator databaseCreator,
@@ -55,11 +65,20 @@ public class CloudStorageDatabase(
     private readonly bool _enableLogging = cloudStorageOptions?.Observability.EnableLogging ?? true;
     private readonly bool _enableTracing = cloudStorageOptions?.Observability.EnableTracing ?? true;
 
+    private readonly CloudStorageRetryExecutor _retryExecutor =
+        new(cloudStorageOptions?.Retry ?? new CloudStorageRetryOptions());
+
+    /// <summary>
+    /// Gets the EF model used by the database implementation.
+    /// </summary>
     public IModel Model { get; } = model ?? throw new ArgumentNullException(nameof(model));
 
     private IDatabaseCreator Creator { get; } =
         databaseCreator ?? throw new ArgumentNullException(nameof(databaseCreator));
 
+    /// <summary>
+    /// Gets the execution strategy factory used for EF infrastructure integration.
+    /// </summary>
     public IExecutionStrategyFactory ExecutionStrategyFactory { get; } = executionStrategyFactory ??
                                                                          throw new ArgumentNullException(
                                                                              nameof(executionStrategyFactory));
@@ -104,6 +123,13 @@ public class CloudStorageDatabase(
         return await ProcessChangesAsync(entries, cancellationToken);
     }
 
+    /// <summary>
+    /// Compiles a query expression into an executable delegate.
+    /// </summary>
+    /// <typeparam name="TResult">The query result type.</typeparam>
+    /// <param name="query">The query expression to compile.</param>
+    /// <param name="async">Whether the query should be compiled for asynchronous execution.</param>
+    /// <returns>A compiled query delegate.</returns>
     public Func<QueryContext, TResult> CompileQuery<TResult>(Expression query, bool async)
     {
         throw new NotImplementedException();
@@ -171,6 +197,13 @@ public class CloudStorageDatabase(
                         var newETag = await ExecuteOrStageSaveAsync(path, entity, null, concurrencyEnabled,
                             cancellationToken);
                         ApplySavedETag(entry, newETag);
+                        if (_enableLogging)
+                        {
+                            _logger?.LogEntitySaved(entry.EntityType.ClrType.Name,
+                                Path.GetFileNameWithoutExtension(path),
+                                "added");
+                        }
+
                         changes++;
                         break;
                     }
@@ -188,6 +221,13 @@ public class CloudStorageDatabase(
                         var newETag = await ExecuteOrStageSaveAsync(path, entity, originalETag, concurrencyEnabled,
                             cancellationToken);
                         ApplySavedETag(entry, newETag);
+                        if (_enableLogging)
+                        {
+                            _logger?.LogEntitySaved(entry.EntityType.ClrType.Name,
+                                Path.GetFileNameWithoutExtension(path),
+                                "updated");
+                        }
+
                         changes++;
                         break;
                     }
@@ -203,6 +243,13 @@ public class CloudStorageDatabase(
                         }
 
                         await ExecuteOrStageDeleteAsync(path, originalETag, concurrencyEnabled, cancellationToken);
+                        if (_enableLogging)
+                        {
+                            _logger?.LogEntitySaved(entry.EntityType.ClrType.Name,
+                                Path.GetFileNameWithoutExtension(path),
+                                "deleted");
+                        }
+
                         changes++;
                         break;
                     }
@@ -255,16 +302,38 @@ public class CloudStorageDatabase(
 
         try
         {
-            if (useConditionalRequest)
+            if (_enableLogging)
             {
-                return await _storageProvider.SaveAsync(path, entity, ifMatchETag);
+                _logger?.LogBlobUploadStarting(path, 0);
             }
 
-            await _storageProvider.SaveAsync(path, entity);
+            if (useConditionalRequest)
+            {
+                var savedEtag = await ExecuteWithRetryAsync(_ => _storageProvider.SaveAsync(path, entity, ifMatchETag),
+                    cancellationToken);
+                if (_enableLogging)
+                {
+                    _logger?.LogBlobUploadCompleted(path, 0);
+                }
+
+                return savedEtag;
+            }
+
+            await ExecuteWithRetryAsync(_ => _storageProvider.SaveAsync(path, entity), cancellationToken);
+            if (_enableLogging)
+            {
+                _logger?.LogBlobUploadCompleted(path, 0);
+            }
+
             return null;
         }
         catch (StoragePreconditionFailedException ex)
         {
+            if (_enableLogging)
+            {
+                _logger?.LogConcurrencyConflict(entity.GetType().Name, Path.GetFileNameWithoutExtension(path), path);
+            }
+
             throw CreateConcurrencyException(path, ex);
         }
     }
@@ -292,16 +361,35 @@ public class CloudStorageDatabase(
 
         try
         {
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDeletionStarting(path);
+            }
+
             if (!useConditionalRequest)
             {
-                await _storageProvider.DeleteAsync(path);
+                await ExecuteWithRetryAsync(_ => _storageProvider.DeleteAsync(path), cancellationToken);
+                if (_enableLogging)
+                {
+                    _logger?.LogBlobDeletionCompleted(path, 0);
+                }
+
                 return;
             }
 
-            await _storageProvider.DeleteAsync(path, ifMatchETag);
+            await ExecuteWithRetryAsync(_ => _storageProvider.DeleteAsync(path, ifMatchETag), cancellationToken);
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDeletionCompleted(path, 0);
+            }
         }
         catch (StoragePreconditionFailedException ex)
         {
+            if (_enableLogging)
+            {
+                _logger?.LogConcurrencyConflict("Entity", Path.GetFileNameWithoutExtension(path), path);
+            }
+
             throw CreateConcurrencyException(path, ex);
         }
     }
@@ -323,6 +411,20 @@ public class CloudStorageDatabase(
             where !Equals(trackedValue, newValue)
             select trackedValue
         ).Any();
+    }
+
+    internal Task ExecuteWithRetryAsync(
+        Func<CancellationToken, Task> operation,
+        CancellationToken cancellationToken = default)
+    {
+        return _retryExecutor.ExecuteAsync(operation, cancellationToken);
+    }
+
+    internal Task<TResult> ExecuteWithRetryAsync<TResult>(
+        Func<CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken = default)
+    {
+        return _retryExecutor.ExecuteAsync(operation, cancellationToken);
     }
 
     Func<QueryContext, TResult> IDatabase.CompileQuery<TResult>(Expression query, bool async)
@@ -402,12 +504,22 @@ public class CloudStorageDatabase(
     private async Task<IList<TEntity>> InternalListAsync<TEntity>(string path, DbContext context)
         where TEntity : class
     {
-        var files = await _storageProvider.ListAsync(path);
+        var files = await ExecuteWithRetryAsync(_ => _storageProvider.ListAsync(path));
         var results = new List<TEntity>();
 
         foreach (var file in files)
         {
-            var storageObject = await _storageProvider.ReadWithMetadataAsync<TEntity>(file);
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDownloadStarting(file);
+            }
+
+            var storageObject = await ExecuteWithRetryAsync(_ => _storageProvider.ReadWithMetadataAsync<TEntity>(file));
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDownloadCompleted(file, 0, 0);
+            }
+
             if (!storageObject.Exists || storageObject.Value is null)
             {
                 continue;
@@ -488,7 +600,17 @@ public class CloudStorageDatabase(
         where TEntity : class
     {
         var path = _blobPathResolver.GetPath(typeof(TEntity), keyValue);
-        var storageObject = await _storageProvider.ReadWithMetadataAsync<TEntity>(path);
+        if (_enableLogging)
+        {
+            _logger?.LogBlobDownloadStarting(path);
+        }
+
+        var storageObject = await ExecuteWithRetryAsync(_ => _storageProvider.ReadWithMetadataAsync<TEntity>(path));
+        if (_enableLogging)
+        {
+            _logger?.LogBlobDownloadCompleted(path, 0, 0);
+        }
+
         var entity = storageObject.Value;
 
         AttachOrReplaceTrackedEntity(context ?? _context, entity, storageObject.ETag);
@@ -520,7 +642,7 @@ public class CloudStorageDatabase(
     {
         var targetContext = context ?? _context;
         var blobName = _blobPathResolver.GetBlobName(typeof(TEntity));
-        var files = await _storageProvider.ListAsync(blobName);
+        var files = await ExecuteWithRetryAsync(_ => _storageProvider.ListAsync(blobName));
         var results = new List<TEntity>();
 
         var entityType = Model.FindEntityType(typeof(TEntity));
@@ -546,7 +668,18 @@ public class CloudStorageDatabase(
                 continue;
             }
 
-            var storageObject = await _storageProvider.ReadWithMetadataAsync<TEntity?>(file);
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDownloadStarting(file);
+            }
+
+            var storageObject =
+                await ExecuteWithRetryAsync(_ => _storageProvider.ReadWithMetadataAsync<TEntity?>(file));
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDownloadCompleted(file, 0, 0);
+            }
+
             if (!storageObject.Exists || storageObject.Value is null)
             {
                 continue;
@@ -644,7 +777,7 @@ public class CloudStorageDatabase(
     public async Task<IList<TEntity>> ToListAsync<TEntity>(string containerName)
         where TEntity : class
     {
-        var files = await _storageProvider.ListAsync(containerName);
+        var files = await ExecuteWithRetryAsync(_ => _storageProvider.ListAsync(containerName));
         var results = new List<TEntity>();
 
         var entityType = _context.Model.FindEntityType(typeof(TEntity));
@@ -652,7 +785,17 @@ public class CloudStorageDatabase(
 
         foreach (var file in files)
         {
-            var storageObject = await _storageProvider.ReadWithMetadataAsync<TEntity?>(file);
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDownloadStarting(file);
+            }
+
+            var storageObject =
+                await ExecuteWithRetryAsync(_ => _storageProvider.ReadWithMetadataAsync<TEntity?>(file));
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDownloadCompleted(file, 0, 0);
+            }
 
             if (!storageObject.Exists || storageObject.Value is null)
             {
@@ -896,7 +1039,8 @@ public class CloudStorageDatabase(
         while (results.Count < take)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var page = await _storageProvider.ListPageAsync(prefix, pageSize, continuationToken, cancellationToken);
+            var page = await ExecuteWithRetryAsync(token =>
+                _storageProvider.ListPageAsync(prefix, pageSize, continuationToken, token), cancellationToken);
 
             if (page.Keys.Count == 0 && !page.HasMore)
             {
@@ -944,7 +1088,18 @@ public class CloudStorageDatabase(
 
         foreach (var path in paths)
         {
-            var storageObject = await _storageProvider.ReadWithMetadataAsync<TEntity?>(path);
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDownloadStarting(path);
+            }
+
+            var storageObject =
+                await ExecuteWithRetryAsync(_ => _storageProvider.ReadWithMetadataAsync<TEntity?>(path));
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDownloadCompleted(path, 0, 0);
+            }
+
             if (!storageObject.Exists || storageObject.Value is null)
             {
                 continue;

--- a/src/CloudStorageORM/Infrastructure/CloudStorageDbContextDependencies.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageDbContextDependencies.cs
@@ -14,15 +14,6 @@ namespace CloudStorageORM.Infrastructure;
 /// </summary>
 public class CloudStorageDbContextDependencies : IDbContextDependencies
 {
-    private readonly IModel _model;
-    private readonly IChangeDetector _changeDetector;
-    private readonly IDbSetSource _setSource;
-    private readonly IEntityGraphAttacher _entityGraphAttacher;
-    private readonly IAsyncQueryProvider _queryProvider;
-    private readonly IStateManager _stateManager;
-    private readonly IExceptionDetector _exceptionDetector;
-    private readonly IDiagnosticsLogger<DbLoggerCategory.Update> _updateLogger;
-    private readonly IDiagnosticsLogger<DbLoggerCategory.Infrastructure> _infrastructureLogger;
     private readonly EntityFinderFactory _entityFinderFactory;
 
     /// <summary>
@@ -37,6 +28,7 @@ public class CloudStorageDbContextDependencies : IDbContextDependencies
     /// <param name="queryProvider">Async query provider.</param>
     /// <param name="stateManager">EF state manager.</param>
     /// <param name="exceptionDetector">EF exception detector.</param>
+    /// <param name="transactionManager">Transaction manager used by the DbContext infrastructure.</param>
     /// <param name="updateLogger">Update diagnostics logger.</param>
     /// <param name="infrastructureLogger">Infrastructure diagnostics logger.</param>
     /// <example>
@@ -54,28 +46,30 @@ public class CloudStorageDbContextDependencies : IDbContextDependencies
         IAsyncQueryProvider queryProvider,
         IStateManager stateManager,
         IExceptionDetector exceptionDetector,
+        IDbContextTransactionManager transactionManager,
         IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger,
         IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger)
     {
-        _model = model ?? throw new ArgumentNullException(nameof(model));
+        Model = model ?? throw new ArgumentNullException(nameof(model));
         if (currentContext == null)
         {
             throw new ArgumentNullException(nameof(currentContext));
         }
 
-        _changeDetector = changeDetector ?? throw new ArgumentNullException(nameof(changeDetector));
-        _setSource = setSource ?? throw new ArgumentNullException(nameof(setSource));
+        ChangeDetector = changeDetector ?? throw new ArgumentNullException(nameof(changeDetector));
+        SetSource = setSource ?? throw new ArgumentNullException(nameof(setSource));
         if (entityFinderSource == null)
         {
             throw new ArgumentNullException(nameof(entityFinderSource));
         }
 
-        _entityGraphAttacher = entityGraphAttacher ?? throw new ArgumentNullException(nameof(entityGraphAttacher));
-        _queryProvider = queryProvider ?? throw new ArgumentNullException(nameof(queryProvider));
-        _stateManager = stateManager ?? throw new ArgumentNullException(nameof(stateManager));
-        _exceptionDetector = exceptionDetector ?? throw new ArgumentNullException(nameof(exceptionDetector));
-        _updateLogger = updateLogger ?? throw new ArgumentNullException(nameof(updateLogger));
-        _infrastructureLogger = infrastructureLogger ?? throw new ArgumentNullException(nameof(infrastructureLogger));
+        EntityGraphAttacher = entityGraphAttacher ?? throw new ArgumentNullException(nameof(entityGraphAttacher));
+        QueryProvider = queryProvider ?? throw new ArgumentNullException(nameof(queryProvider));
+        StateManager = stateManager ?? throw new ArgumentNullException(nameof(stateManager));
+        ExceptionDetector = exceptionDetector ?? throw new ArgumentNullException(nameof(exceptionDetector));
+        TransactionManager = transactionManager ?? throw new ArgumentNullException(nameof(transactionManager));
+        UpdateLogger = updateLogger ?? throw new ArgumentNullException(nameof(updateLogger));
+        InfrastructureLogger = infrastructureLogger ?? throw new ArgumentNullException(nameof(infrastructureLogger));
 
         _entityFinderFactory = new EntityFinderFactory(
             entityFinderSource,
@@ -85,27 +79,29 @@ public class CloudStorageDbContextDependencies : IDbContextDependencies
         );
     }
 
-    public IDbContextTransactionManager TransactionManager => new CloudStorageTransactionManager();
-    public IModel Model => _model;
-    public IModel DesignTimeModel => _model; // Returning the same model for design-time usage
+    public IDbContextTransactionManager TransactionManager { get; }
+
+    public IModel Model { get; }
+
+    public IModel DesignTimeModel => Model; // Returning the same model for design-time usage
     public DbContextOptions ContextOptions => throw new NotImplementedException();
     public IServiceProvider InternalServiceProvider => throw new NotImplementedException();
 
-    public IDbSetSource SetSource => _setSource;
+    public IDbSetSource SetSource { get; }
 
     public IEntityFinderFactory EntityFinderFactory => _entityFinderFactory;
 
-    public IAsyncQueryProvider QueryProvider => _queryProvider;
+    public IAsyncQueryProvider QueryProvider { get; }
 
-    public IStateManager StateManager => _stateManager;
+    public IStateManager StateManager { get; }
 
-    public IChangeDetector ChangeDetector => _changeDetector;
+    public IChangeDetector ChangeDetector { get; }
 
-    public IEntityGraphAttacher EntityGraphAttacher => _entityGraphAttacher;
+    public IEntityGraphAttacher EntityGraphAttacher { get; }
 
-    public IExceptionDetector ExceptionDetector => _exceptionDetector;
+    public IExceptionDetector ExceptionDetector { get; }
 
-    public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger => _updateLogger;
+    public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
 
-    public IDiagnosticsLogger<DbLoggerCategory.Infrastructure> InfrastructureLogger => _infrastructureLogger;
+    public IDiagnosticsLogger<DbLoggerCategory.Infrastructure> InfrastructureLogger { get; }
 }

--- a/src/CloudStorageORM/Infrastructure/CloudStorageLoggingDefinitions.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageLoggingDefinitions.cs
@@ -2,6 +2,9 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace CloudStorageORM.Infrastructure;
 
+/// <summary>
+/// CloudStorageORM-specific logging definitions used by EF Core infrastructure wiring.
+/// </summary>
 public class CloudStorageLoggingDefinitions : LoggingDefinitions
 {
 }

--- a/src/CloudStorageORM/Infrastructure/CloudStorageOrmOptionsExtension.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageOrmOptionsExtension.cs
@@ -13,6 +13,7 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace CloudStorageORM.Infrastructure;
 
@@ -63,7 +64,11 @@ public class CloudStorageOrmOptionsExtension : IDbContextOptionsExtension
 
         services.AddSingleton<IBlobPathResolver, BlobPathResolver>();
         services.AddSingleton<ITypeMappingSource, CloudStorageTypeMappingSource>();
-        services.AddScoped<IDbContextTransactionManager, CloudStorageTransactionManager>();
+        services.AddScoped<IDbContextTransactionManager>(sp =>
+            new CloudStorageTransactionManager(
+                sp.GetRequiredService<IStorageProvider>(),
+                sp.GetRequiredService<CloudStorageOptions>(),
+                ResolveTransactionManagerLogger(sp)));
         services.AddSingleton<IDatabaseCreator, CloudStorageDatabaseCreator>();
         services.AddSingleton<IModelSource, ModelSource>();
         services.AddSingleton<IModelRuntimeInitializer, ModelRuntimeInitializer>();
@@ -78,5 +83,27 @@ public class CloudStorageOrmOptionsExtension : IDbContextOptionsExtension
     public void Validate(IDbContextOptions options)
     {
         CloudStorageOptionsValidator.Validate(Options);
+    }
+
+    private static ILogger<CloudStorageTransactionManager>? ResolveTransactionManagerLogger(
+        IServiceProvider serviceProvider)
+    {
+        var logger = serviceProvider.GetService<ILogger<CloudStorageTransactionManager>>();
+        if (logger is not null)
+        {
+            return logger;
+        }
+
+        var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+        if (loggerFactory is not null)
+        {
+            return loggerFactory.CreateLogger<CloudStorageTransactionManager>();
+        }
+
+        var dbContextOptions = serviceProvider.GetService<IDbContextOptions>();
+        var coreOptionsExtension = dbContextOptions?.Extensions.OfType<CoreOptionsExtension>().FirstOrDefault();
+        loggerFactory = coreOptionsExtension?.LoggerFactory;
+
+        return loggerFactory?.CreateLogger<CloudStorageTransactionManager>();
     }
 }

--- a/src/CloudStorageORM/Infrastructure/CloudStorageQueryContext.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageQueryContext.cs
@@ -2,4 +2,7 @@ using Microsoft.EntityFrameworkCore.Query;
 
 namespace CloudStorageORM.Infrastructure;
 
+/// <summary>
+/// CloudStorageORM-specific query context that reuses EF Core query infrastructure.
+/// </summary>
 public class CloudStorageQueryContext(QueryContextDependencies dependencies) : QueryContext(dependencies);

--- a/src/CloudStorageORM/Infrastructure/CloudStorageQueryProvider.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageQueryProvider.cs
@@ -52,13 +52,13 @@ public class CloudStorageQueryProvider(
     /// <inheritdoc />
     public object Execute(Expression expression)
     {
-        return ExecuteCoreAsync<object>(expression).GetAwaiter().GetResult();
+        return ExecuteCoreAsync<object>(expression, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc />
     public TResult Execute<TResult>(Expression expression)
     {
-        return ExecuteCoreAsync<TResult>(expression).GetAwaiter().GetResult();
+        return ExecuteCoreAsync<TResult>(expression, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <summary>
@@ -76,30 +76,35 @@ public class CloudStorageQueryProvider(
     public async Task<TResult> ExecuteAsync<TResult>(Expression expression,
         CancellationToken cancellationToken = default)
     {
-        return await ExecuteCoreAsync<TResult>(expression);
+        return await ExecuteCoreAsync<TResult>(expression, cancellationToken);
     }
 
     TResult IAsyncQueryProvider.ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
     {
-        return Execute<TResult>(expression);
+        return ExecuteCoreAsync<TResult>(expression, cancellationToken).GetAwaiter().GetResult();
     }
 
-    private async Task<TResult> ExecuteCoreAsync<TResult>(Expression expression)
+    private async Task<TResult> ExecuteCoreAsync<TResult>(Expression expression, CancellationToken cancellationToken)
     {
         var elementType = ResolveEntityType(expression, typeof(TResult));
         var executeMethod = typeof(CloudStorageQueryProvider)
             .GetMethod(nameof(ExecuteTypedAsync), BindingFlags.Instance | BindingFlags.NonPublic)!
             .MakeGenericMethod(elementType, typeof(TResult));
 
-        var task = (Task)executeMethod.Invoke(this, [expression])!;
-        await task.ConfigureAwait(false);
-        var resultProperty = task.GetType().GetProperty("Result")!;
-        return (TResult)resultProperty.GetValue(task)!;
+        return await _database.ExecuteWithRetryAsync(async token =>
+        {
+            var task = (Task)executeMethod.Invoke(this, [expression, token])!;
+            await task.ConfigureAwait(false);
+            var resultProperty = task.GetType().GetProperty("Result")!;
+            return (TResult)resultProperty.GetValue(task)!;
+        }, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<TResult> ExecuteTypedAsync<TEntity, TResult>(Expression expression)
+    private async Task<TResult> ExecuteTypedAsync<TEntity, TResult>(Expression expression,
+        CancellationToken cancellationToken)
         where TEntity : class
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var activity = _enableTracing ? CloudStorageOrmActivitySource.StartActivity("Query") : null;
         var stopwatch = Stopwatch.StartNew();
 
@@ -660,60 +665,66 @@ public class CloudStorageQueryProvider(
     private static bool TryMergePrimaryKeyConstraints(PrimaryKeyConstraint left, PrimaryKeyConstraint right,
         out PrimaryKeyConstraint merged)
     {
-        merged = PrimaryKeyConstraint.None;
-
-        if (left.IsNone || right.IsNone)
+        while (true)
         {
-            return false;
-        }
+            merged = PrimaryKeyConstraint.None;
 
-        if (left.IsEquality && right.IsEquality)
-        {
-            if (!Equals(left.EqualityValue, right.EqualityValue))
+            if (left.IsNone || right.IsNone)
             {
                 return false;
             }
 
-            merged = left;
+            switch (left.IsEquality)
+            {
+                case true when right.IsEquality:
+                {
+                    if (!Equals(left.EqualityValue, right.EqualityValue))
+                    {
+                        return false;
+                    }
+
+                    merged = left;
+                    return true;
+                }
+                case true:
+                {
+                    (left, right) = (right, left);
+                    continue;
+                }
+            }
+
+            if (right.IsEquality)
+            {
+                var equality = right.EqualityValue;
+                if (equality is null)
+                {
+                    return false;
+                }
+
+                if (!IsEqualityWithinRange(left, equality))
+                {
+                    return false;
+                }
+
+                merged = right;
+                return true;
+            }
+
+            var (lowerBound, lowerInclusive) = SelectLowerBound(left, right);
+            var (upperBound, upperInclusive) = SelectUpperBound(left, right);
+
+            if (lowerBound is not null && upperBound is not null)
+            {
+                var compare = CompareComparable(lowerBound, upperBound);
+                if (compare > 0 || (compare == 0 && (!lowerInclusive || !upperInclusive)))
+                {
+                    return false;
+                }
+            }
+
+            merged = PrimaryKeyConstraint.ForRange(lowerBound, lowerInclusive, upperBound, upperInclusive);
             return true;
         }
-
-        if (left.IsEquality)
-        {
-            return TryMergePrimaryKeyConstraints(right, left, out merged);
-        }
-
-        if (right.IsEquality)
-        {
-            var equality = right.EqualityValue;
-            if (equality is null)
-            {
-                return false;
-            }
-
-            if (!IsEqualityWithinRange(left, equality))
-            {
-                return false;
-            }
-
-            merged = right;
-            return true;
-        }
-
-        var (lowerBound, lowerInclusive) = SelectLowerBound(left, right);
-        var (upperBound, upperInclusive) = SelectUpperBound(left, right);
-
-        if (lowerBound is not null && upperBound is not null)
-        {
-            var compare = CompareComparable(lowerBound, upperBound);
-            if (compare > 0 || (compare == 0 && (!lowerInclusive || !upperInclusive)))
-            {
-                return false;
-            }
-        }
-
-        merged = PrimaryKeyConstraint.ForRange(lowerBound, lowerInclusive, upperBound, upperInclusive);
-        return true;
     }
 
     private static (object? lowerBound, bool lowerInclusive) SelectLowerBound(PrimaryKeyConstraint left,
@@ -907,8 +918,8 @@ public class CloudStorageQueryProvider(
                 return node;
             }
 
-            if (node.Method.DeclaringType == typeof(Queryable)
-                && node.Method.Name is nameof(Queryable.OrderBy)
+            if (node.Method.DeclaringType != typeof(Queryable)
+                || node.Method.Name is not (nameof(Queryable.OrderBy)
                     or nameof(Queryable.OrderByDescending)
                     or nameof(Queryable.ThenBy)
                     or nameof(Queryable.ThenByDescending)
@@ -916,13 +927,13 @@ public class CloudStorageQueryProvider(
                     or nameof(Queryable.SelectMany)
                     or nameof(Queryable.Reverse)
                     or nameof(Queryable.GroupBy)
-                    or nameof(Queryable.Distinct))
+                    or nameof(Queryable.Distinct)))
             {
-                HasUnsupportedOperator = true;
-                return node;
+                return base.VisitMethodCall(node);
             }
 
-            return base.VisitMethodCall(node);
+            HasUnsupportedOperator = true;
+            return node;
         }
     }
 

--- a/src/CloudStorageORM/Infrastructure/CloudStorageRetryExecutor.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageRetryExecutor.cs
@@ -1,0 +1,127 @@
+using CloudStorageORM.Options;
+
+namespace CloudStorageORM.Infrastructure;
+
+/// <summary>
+/// Executes operations with bounded transient-fault retries and exponential backoff.
+/// </summary>
+internal sealed class CloudStorageRetryExecutor
+{
+    private readonly CloudStorageRetryOptions _options;
+    private readonly Func<Exception, bool> _isTransient;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+    private readonly Func<double> _nextRandom;
+
+    /// <summary>
+    /// Creates a retry executor using the supplied retry options.
+    /// </summary>
+    /// <param name="options">Retry options controlling retry count, backoff, and jitter.</param>
+    public CloudStorageRetryExecutor(CloudStorageRetryOptions options)
+        : this(options, CloudStorageTransientExceptionClassifier.IsTransient, Task.Delay,
+            () => Random.Shared.NextDouble())
+    {
+    }
+
+    internal CloudStorageRetryExecutor(
+        CloudStorageRetryOptions options,
+        Func<Exception, bool> isTransient,
+        Func<TimeSpan, CancellationToken, Task> delayAsync,
+        Func<double> nextRandom)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _isTransient = isTransient ?? throw new ArgumentNullException(nameof(isTransient));
+        _delayAsync = delayAsync ?? throw new ArgumentNullException(nameof(delayAsync));
+        _nextRandom = nextRandom ?? throw new ArgumentNullException(nameof(nextRandom));
+    }
+
+    /// <summary>
+    /// Executes an asynchronous operation with retry handling for transient failures.
+    /// </summary>
+    /// <param name="operation">Operation to invoke.</param>
+    /// <param name="cancellationToken">Cancellation token used for the operation and any retry delay.</param>
+    public async Task ExecuteAsync(Func<CancellationToken, Task> operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        await ExecuteAsync<object?>(
+            async token =>
+            {
+                await operation(token).ConfigureAwait(false);
+                return null;
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes an asynchronous operation with retry handling for transient failures and a typed result.
+    /// </summary>
+    /// <typeparam name="TResult">Result type produced by the operation.</typeparam>
+    /// <param name="operation">Operation to invoke.</param>
+    /// <param name="cancellationToken">Cancellation token used for the operation and any retry delay.</param>
+    /// <returns>The operation result.</returns>
+    public async Task<TResult> ExecuteAsync<TResult>(
+        Func<CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var retryCount = 0;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                return await operation(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ShouldRetry(ex, retryCount, cancellationToken))
+            {
+                retryCount++;
+                var delay = ComputeDelay(retryCount);
+                if (delay > TimeSpan.Zero)
+                {
+                    await _delayAsync(delay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private bool ShouldRetry(Exception exception, int retryCount, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || retryCount >= _options.MaxRetries)
+        {
+            return false;
+        }
+
+        if (exception is OperationCanceledException && cancellationToken.IsCancellationRequested)
+        {
+            return false;
+        }
+
+        return _isTransient(exception);
+    }
+
+    private TimeSpan ComputeDelay(int retryAttempt)
+    {
+        if (_options.BaseDelay <= TimeSpan.Zero || _options.MaxDelay <= TimeSpan.Zero)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var exponent = Math.Max(0, retryAttempt - 1);
+        var uncappedMilliseconds = _options.BaseDelay.TotalMilliseconds * Math.Pow(2d, exponent);
+        var cappedMilliseconds = Math.Min(uncappedMilliseconds, _options.MaxDelay.TotalMilliseconds);
+
+        if (_options.JitterFactor <= 0d)
+        {
+            return TimeSpan.FromMilliseconds(cappedMilliseconds);
+        }
+
+        var jitterWindow = cappedMilliseconds * _options.JitterFactor;
+        var jitterOffset = ((_nextRandom() * 2d) - 1d) * jitterWindow;
+        var jitteredMilliseconds = Math.Max(0d, cappedMilliseconds + jitterOffset);
+
+        return TimeSpan.FromMilliseconds(jitteredMilliseconds);
+    }
+}

--- a/src/CloudStorageORM/Infrastructure/CloudStorageTransactionManager.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageTransactionManager.cs
@@ -1,7 +1,10 @@
 using System.Text.Json;
 using CloudStorageORM.Interfaces.StorageProviders;
+using CloudStorageORM.Observability;
+using CloudStorageORM.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
 
 namespace CloudStorageORM.Infrastructure;
 
@@ -13,9 +16,15 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
     private const string TransactionPrefix = "__cloudstorageorm/tx";
 
     private readonly IStorageProvider? _storageProvider;
+    private readonly ILogger<CloudStorageTransactionManager>? _logger;
+    private readonly bool _enableLogging;
+    private readonly bool _enableTracing;
     private readonly Lock _sync = new();
+
     private readonly List<Func<CancellationToken, Task>> _pendingOperations = [];
-    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+
+    // Preserve CLR property names in staged payloads so provider deserialization maps back to entity members.
+    private readonly JsonSerializerOptions _jsonOptions = new();
     private CloudStorageDbContextTransaction? _currentTransaction;
     private DurableTransactionManifest? _activeManifest;
     private bool _recoveryCompleted;
@@ -24,21 +33,31 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
     /// Creates a transaction manager without durable journal support.
     /// </summary>
     public CloudStorageTransactionManager()
+        : this(storageProvider: null, cloudStorageOptions: null, logger: null)
     {
     }
 
     /// <summary>
-    /// Creates a transaction manager with durable journal support backed by object storage.
+    /// Creates a transaction manager with optional storage, observability options, and logger.
     /// </summary>
     /// <param name="storageProvider">Storage provider used to persist transaction manifests.</param>
-    public CloudStorageTransactionManager(IStorageProvider storageProvider)
+    /// <param name="cloudStorageOptions">Cloud storage options controlling observability toggles.</param>
+    /// <param name="logger">Logger used for runtime transaction events.</param>
+    public CloudStorageTransactionManager(
+        IStorageProvider? storageProvider,
+        CloudStorageOptions? cloudStorageOptions = null,
+        ILogger<CloudStorageTransactionManager>? logger = null)
     {
         _storageProvider = storageProvider;
+        _logger = logger;
+        _enableLogging = cloudStorageOptions?.Observability.EnableLogging ?? true;
+        _enableTracing = cloudStorageOptions?.Observability.EnableTracing ?? true;
     }
 
     /// <inheritdoc />
     public IDbContextTransaction BeginTransaction()
     {
+        using var activity = _enableTracing ? CloudStorageOrmActivitySource.StartActivity("TransactionBegin") : null;
         EnsureRecoveryCompletedAsync(CancellationToken.None).GetAwaiter().GetResult();
 
         lock (_sync)
@@ -51,6 +70,10 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
             _pendingOperations.Clear();
             _currentTransaction = new CloudStorageDbContextTransaction(this);
             _activeManifest = DurableTransactionManifest.Create(_currentTransaction.TransactionId);
+            if (_enableLogging)
+            {
+                _logger?.LogTransactionBeginning(_currentTransaction.TransactionId.ToString("D"));
+            }
 
             return _currentTransaction;
         }
@@ -207,43 +230,74 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
     internal async Task CommitTransactionInternalAsync(CloudStorageDbContextTransaction transaction,
         CancellationToken cancellationToken)
     {
+        using var activity = _enableTracing ? CloudStorageOrmActivitySource.StartActivity("TransactionCommit") : null;
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         var state = CaptureAndCloseTransaction(transaction);
 
-        if (_storageProvider is not null && state.Manifest is not null)
+        try
         {
-            state.Manifest.State = DurableTransactionState.Committed;
-            state.Manifest.CommittedAtUtc = DateTimeOffset.UtcNow;
-            await PersistManifestAsync(state.Manifest, cancellationToken);
+            if (_storageProvider is not null && state.Manifest is not null)
+            {
+                state.Manifest.State = DurableTransactionState.Committed;
+                state.Manifest.CommittedAtUtc = DateTimeOffset.UtcNow;
+                await PersistManifestAsync(state.Manifest, cancellationToken);
 
-            await ApplyDurableOperationsAsync(state.Manifest, cancellationToken);
+                await ApplyDurableOperationsAsync(state.Manifest, cancellationToken);
 
-            state.Manifest.State = DurableTransactionState.Completed;
-            state.Manifest.CompletedAtUtc = DateTimeOffset.UtcNow;
-            await PersistManifestAsync(state.Manifest, cancellationToken);
+                state.Manifest.State = DurableTransactionState.Completed;
+                state.Manifest.CompletedAtUtc = DateTimeOffset.UtcNow;
+                await PersistManifestAsync(state.Manifest, cancellationToken);
+            }
+
+            foreach (var operation in state.PendingOperations)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await operation(cancellationToken);
+            }
+
+            stopwatch.Stop();
+            if (_enableLogging)
+            {
+                _logger?.LogTransactionCommitted(transaction.TransactionId.ToString("D"),
+                    stopwatch.ElapsedMilliseconds);
+            }
         }
-
-        foreach (var operation in state.PendingOperations)
+        catch (Exception ex)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            await operation(cancellationToken);
+            stopwatch.Stop();
+            activity?.SetStatus(System.Diagnostics.ActivityStatusCode.Error, ex.Message);
+            throw;
         }
     }
 
-    internal Task RollbackTransactionInternalAsync(CloudStorageDbContextTransaction transaction,
+    internal async Task RollbackTransactionInternalAsync(CloudStorageDbContextTransaction transaction,
         CancellationToken cancellationToken)
     {
+        using var activity = _enableTracing ? CloudStorageOrmActivitySource.StartActivity("TransactionRollback") : null;
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         cancellationToken.ThrowIfCancellationRequested();
         var state = CaptureAndCloseTransaction(transaction);
 
         if (_storageProvider is null || state.Manifest is null)
         {
-            return Task.CompletedTask;
+            stopwatch.Stop();
+            if (_enableLogging)
+            {
+                _logger?.LogTransactionRolledBack(transaction.TransactionId.ToString("D"),
+                    stopwatch.ElapsedMilliseconds);
+            }
+
+            return;
         }
 
         state.Manifest.State = DurableTransactionState.Aborted;
         state.Manifest.CompletedAtUtc = DateTimeOffset.UtcNow;
-        return PersistManifestAsync(state.Manifest, cancellationToken);
-
+        await PersistManifestAsync(state.Manifest, cancellationToken);
+        stopwatch.Stop();
+        if (_enableLogging)
+        {
+            _logger?.LogTransactionRolledBack(transaction.TransactionId.ToString("D"), stopwatch.ElapsedMilliseconds);
+        }
     }
 
     private CloudStorageDbContextTransaction GetCurrentTransactionOrThrow()
@@ -274,48 +328,50 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
         }
     }
 
-     private async Task EnsureRecoveryCompletedAsync(CancellationToken cancellationToken)
-     {
-         if (_storageProvider is null || _recoveryCompleted)
-         {
-             return;
-         }
+    private async Task EnsureRecoveryCompletedAsync(CancellationToken cancellationToken)
+    {
+        using var activity = _enableTracing ? CloudStorageOrmActivitySource.StartActivity("TransactionRecovery") : null;
+        if (_storageProvider is null || _recoveryCompleted)
+        {
+            return;
+        }
 
-         var manifestPaths = await _storageProvider.ListAsync(TransactionPrefix);
-         var manifests = manifestPaths.Where(path => path.EndsWith("/manifest.json", StringComparison.OrdinalIgnoreCase));
+        var manifestPaths = await _storageProvider.ListAsync(TransactionPrefix);
+        var manifests =
+            manifestPaths.Where(path => path.EndsWith("/manifest.json", StringComparison.OrdinalIgnoreCase));
 
-         foreach (var manifestPath in manifests)
-         {
-             cancellationToken.ThrowIfCancellationRequested();
-             var manifest = await _storageProvider.ReadAsync<DurableTransactionManifest>(manifestPath);
-             if (manifest.TransactionId == Guid.Empty)
-             {
-                 continue;
-             }
+        foreach (var manifestPath in manifests)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var manifest = await _storageProvider.ReadAsync<DurableTransactionManifest>(manifestPath);
+            if (manifest.TransactionId == Guid.Empty)
+            {
+                continue;
+            }
 
-             switch (manifest.State)
-             {
-                 case DurableTransactionState.Committed:
-                     // Resume replay from where it left off, skipping already-applied operations.
-                     // If all operations are applied (AppliedOperationCount == Operations.Count),
-                     // this becomes a no-op and transitions directly to Completed.
-                     await ApplyDurableOperationsAsync(manifest, cancellationToken);
-                     manifest.State = DurableTransactionState.Completed;
-                     manifest.CompletedAtUtc = DateTimeOffset.UtcNow;
-                     await PersistManifestAsync(manifest, cancellationToken);
-                     break;
+            switch (manifest.State)
+            {
+                case DurableTransactionState.Committed:
+                    // Resume replay from where it left off, skipping already-applied operations.
+                    // If all operations are applied (AppliedOperationCount == Operations.Count),
+                    // this becomes a no-op and transitions directly to "Completed".
+                    await ApplyDurableOperationsAsync(manifest, cancellationToken);
+                    manifest.State = DurableTransactionState.Completed;
+                    manifest.CompletedAtUtc = DateTimeOffset.UtcNow;
+                    await PersistManifestAsync(manifest, cancellationToken);
+                    break;
 
-                 case DurableTransactionState.Preparing:
-                     // Uncommitted preparing transactions are safely aborted without losing data.
-                     manifest.State = DurableTransactionState.Aborted;
-                     manifest.CompletedAtUtc = DateTimeOffset.UtcNow;
-                     await PersistManifestAsync(manifest, cancellationToken);
-                     break;
-             }
-         }
+                case DurableTransactionState.Preparing:
+                    // Uncommitted preparing transactions are safely aborted without losing data.
+                    manifest.State = DurableTransactionState.Aborted;
+                    manifest.CompletedAtUtc = DateTimeOffset.UtcNow;
+                    await PersistManifestAsync(manifest, cancellationToken);
+                    break;
+            }
+        }
 
-         _recoveryCompleted = true;
-     }
+        _recoveryCompleted = true;
+    }
 
     private async Task PersistManifestAsync(DurableTransactionManifest manifest, CancellationToken cancellationToken)
     {
@@ -325,57 +381,87 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
         }
 
         cancellationToken.ThrowIfCancellationRequested();
+        if (_enableLogging)
+        {
+            _logger?.LogBlobUploadStarting(GetManifestPath(manifest.TransactionId), manifest.Operations.Count);
+        }
+
         await _storageProvider.SaveAsync(GetManifestPath(manifest.TransactionId), manifest);
+
+        if (_enableLogging)
+        {
+            _logger?.LogBlobUploadCompleted(GetManifestPath(manifest.TransactionId), 0);
+        }
     }
 
-     private async Task ApplyDurableOperationsAsync(DurableTransactionManifest manifest, CancellationToken cancellationToken)
-     {
-         if (_storageProvider is null)
-         {
-             return;
-         }
+    private async Task ApplyDurableOperationsAsync(DurableTransactionManifest manifest,
+        CancellationToken cancellationToken)
+    {
+        if (_storageProvider is null)
+        {
+            return;
+        }
 
-         var startIndex = manifest.AppliedOperationCount;
-         var operations = manifest.Operations.OrderBy(x => x.Sequence).ToList();
+        var startIndex = manifest.AppliedOperationCount;
+        var operations = manifest.Operations.OrderBy(x => x.Sequence).ToList();
 
-         for (var i = startIndex; i < operations.Count; i++)
-         {
-             cancellationToken.ThrowIfCancellationRequested();
+        for (var i = startIndex; i < operations.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
 
-             var operation = operations[i];
-             switch (operation.Kind)
-             {
-                 case DurableTransactionOperationKind.Save:
-                     var payloadJson = string.IsNullOrWhiteSpace(operation.PayloadJson) ? "{}" : operation.PayloadJson;
-                     var payload = JsonSerializer.Deserialize<JsonElement>(payloadJson);
-                     await SaveDurableOperationAsync(operation, payload);
-                     break;
+            var operation = operations[i];
+            switch (operation.Kind)
+            {
+                case DurableTransactionOperationKind.Save:
+                    var payloadJson = string.IsNullOrWhiteSpace(operation.PayloadJson) ? "{}" : operation.PayloadJson;
+                    var payload = JsonSerializer.Deserialize<JsonElement>(payloadJson);
+                    await SaveDurableOperationAsync(operation, payload);
+                    break;
 
-                 case DurableTransactionOperationKind.Delete:
-                     await DeleteDurableOperationAsync(operation);
-                     break;
-             }
+                case DurableTransactionOperationKind.Delete:
+                    await DeleteDurableOperationAsync(operation);
+                    break;
+            }
 
-             // Update progress marker after each operation is applied successfully.
-             manifest.AppliedOperationCount = i + 1;
-             await PersistManifestAsync(manifest, cancellationToken);
-         }
-     }
+            // Update progress marker after each operation is applied successfully.
+            manifest.AppliedOperationCount = i + 1;
+            await PersistManifestAsync(manifest, cancellationToken);
+        }
+    }
 
     private async Task SaveDurableOperationAsync(DurableTransactionOperation operation, JsonElement payload)
     {
         try
         {
+            if (_enableLogging)
+            {
+                _logger?.LogBlobUploadStarting(operation.Path, operation.PayloadJson?.Length ?? 0);
+            }
+
             if (string.IsNullOrWhiteSpace(operation.IfMatchETag))
             {
                 await _storageProvider!.SaveAsync(operation.Path, payload);
+                if (_enableLogging)
+                {
+                    _logger?.LogBlobUploadCompleted(operation.Path, 0);
+                }
+
                 return;
             }
 
             await _storageProvider!.SaveAsync(operation.Path, payload, operation.IfMatchETag);
+            if (_enableLogging)
+            {
+                _logger?.LogBlobUploadCompleted(operation.Path, 0);
+            }
         }
         catch (StoragePreconditionFailedException ex)
         {
+            if (_enableLogging)
+            {
+                _logger?.LogConcurrencyConflict("DurableTransactionOperation", null, operation.Path);
+            }
+
             throw CreateConcurrencyException(operation.Path, ex);
         }
     }
@@ -384,16 +470,35 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
     {
         try
         {
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDeletionStarting(operation.Path);
+            }
+
             if (string.IsNullOrWhiteSpace(operation.IfMatchETag))
             {
                 await _storageProvider!.DeleteAsync(operation.Path);
+                if (_enableLogging)
+                {
+                    _logger?.LogBlobDeletionCompleted(operation.Path, 0);
+                }
+
                 return;
             }
 
             await _storageProvider!.DeleteAsync(operation.Path, operation.IfMatchETag);
+            if (_enableLogging)
+            {
+                _logger?.LogBlobDeletionCompleted(operation.Path, 0);
+            }
         }
         catch (StoragePreconditionFailedException ex)
         {
+            if (_enableLogging)
+            {
+                _logger?.LogConcurrencyConflict("DurableTransactionOperation", null, operation.Path);
+            }
+
             throw CreateConcurrencyException(operation.Path, ex);
         }
     }
@@ -408,7 +513,8 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
     private static string GetManifestPath(Guid transactionId)
         => $"{TransactionPrefix}/{transactionId:D}/manifest.json";
 
-    private (CloudStorageDbContextTransaction Transaction, DurableTransactionManifest Manifest) GetActiveTransactionState()
+    private (CloudStorageDbContextTransaction Transaction, DurableTransactionManifest Manifest)
+        GetActiveTransactionState()
     {
         lock (_sync)
         {
@@ -457,42 +563,47 @@ public class CloudStorageTransactionManager : IDbContextTransactionManager
         public string? IfMatchETag { get; init; }
     }
 
-     private sealed class DurableTransactionManifest
-     {
-         // ReSharper disable once MemberCanBePrivate.Local
-         // ReSharper disable once PropertyCanBeMadeInitOnly.Local
-         public Guid TransactionId { get; set; }
-         public DurableTransactionState State { get; set; }
-         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-         public DateTimeOffset CreatedAtUtc { get; set; }
-         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-         public DateTimeOffset? CommittedAtUtc { get; set; }
-         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-         public DateTimeOffset? CompletedAtUtc { get; set; }
-         // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
-         public List<DurableTransactionOperation> Operations { get; set; } = [];
-         /// <summary>
-         /// Tracks the number of operations that have been successfully applied to storage.
-         /// Used to resume replay after interruption without re-applying operations.
-         /// Value is 0 for new transactions, incremented as operations are applied during commit/recovery.
-         /// When AppliedOperationCount equals Operations.Count, all operations have been applied.
-         /// </summary>
-         public int AppliedOperationCount { get; set; }
+    private sealed class DurableTransactionManifest
+    {
+        // ReSharper disable once MemberCanBePrivate.Local
+        // ReSharper disable once PropertyCanBeMadeInitOnly.Local
+        public Guid TransactionId { get; set; }
+        public DurableTransactionState State { get; set; }
 
-         /// <summary>
-         /// Creates a new manifest for a transaction in the preparing state.
-         /// </summary>
-         /// <param name="transactionId">Unique transaction identifier.</param>
-         /// <returns>A new durable transaction manifest.</returns>
-         public static DurableTransactionManifest Create(Guid transactionId)
-         {
-             return new DurableTransactionManifest
-             {
-                 TransactionId = transactionId,
-                 State = DurableTransactionState.Preparing,
-                 CreatedAtUtc = DateTimeOffset.UtcNow,
-                 AppliedOperationCount = 0
-             };
-         }
-     }
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
+        public DateTimeOffset CreatedAtUtc { get; set; }
+
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
+        public DateTimeOffset? CommittedAtUtc { get; set; }
+
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
+        public DateTimeOffset? CompletedAtUtc { get; set; }
+
+        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
+        public List<DurableTransactionOperation> Operations { get; set; } = [];
+
+        /// <summary>
+        /// Tracks the number of operations that have been successfully applied to storage.
+        /// Used to resume replay after interruption without re-applying operations.
+        /// Value is 0 for new transactions, incremented as operations are applied during commit/recovery.
+        /// When AppliedOperationCount equals Operations.Count, all operations have been applied.
+        /// </summary>
+        public int AppliedOperationCount { get; set; }
+
+        /// <summary>
+        /// Creates a new manifest for a transaction in the preparing state.
+        /// </summary>
+        /// <param name="transactionId">Unique transaction identifier.</param>
+        /// <returns>A new durable transaction manifest.</returns>
+        public static DurableTransactionManifest Create(Guid transactionId)
+        {
+            return new DurableTransactionManifest
+            {
+                TransactionId = transactionId,
+                State = DurableTransactionState.Preparing,
+                CreatedAtUtc = DateTimeOffset.UtcNow,
+                AppliedOperationCount = 0
+            };
+        }
+    }
 }

--- a/src/CloudStorageORM/Infrastructure/CloudStorageTransientExceptionClassifier.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageTransientExceptionClassifier.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using Amazon.Runtime;
+using Amazon.S3;
+using Azure;
+using Microsoft.EntityFrameworkCore;
+
+namespace CloudStorageORM.Infrastructure;
+
+/// <summary>
+/// Classifies exceptions that are safe to retry at CloudStorageORM's shared execution boundaries.
+/// </summary>
+internal static class CloudStorageTransientExceptionClassifier
+{
+    private static readonly HashSet<int> TransientStatusCodes = [408, 429, 500, 502, 503, 504];
+
+    private static readonly HashSet<string> AwsTransientErrorCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "RequestTimeout",
+        "RequestTimeoutException",
+        "Throttling",
+        "ThrottlingException",
+        "SlowDown",
+        "InternalError",
+        "ServiceUnavailable",
+        "TooManyRequestsException"
+    };
+
+    /// <summary>
+    /// Determines whether the provided exception should be treated as transient.
+    /// </summary>
+    /// <param name="exception">The exception to classify.</param>
+    /// <returns><see langword="true" /> when the exception is considered transient; otherwise <see langword="false" />.</returns>
+    public static bool IsTransient(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        return exception switch
+        {
+            StoragePreconditionFailedException or DbUpdateConcurrencyException => false,
+            TimeoutException or HttpRequestException or IOException or TaskCanceledException => true,
+            RequestFailedException requestFailedException => TransientStatusCodes.Contains(
+                requestFailedException.Status),
+            AmazonS3Exception s3Exception => IsAwsTransientStatusCode(s3Exception.StatusCode) ||
+                                             IsAwsTransientErrorCode(s3Exception.ErrorCode),
+            AmazonServiceException amazonServiceException =>
+                IsAwsTransientStatusCode(amazonServiceException.StatusCode) ||
+                IsAwsTransientErrorCode(amazonServiceException.ErrorCode),
+            _ => exception.InnerException is not null && IsTransient(exception.InnerException)
+        };
+    }
+
+    private static bool IsAwsTransientStatusCode(HttpStatusCode statusCode)
+    {
+        return statusCode != 0 && TransientStatusCodes.Contains((int)statusCode);
+    }
+
+    private static bool IsAwsTransientErrorCode(string? errorCode)
+    {
+        return !string.IsNullOrWhiteSpace(errorCode) && AwsTransientErrorCodes.Contains(errorCode);
+    }
+}

--- a/src/CloudStorageORM/Infrastructure/CloudStorageTypeMappingSource.cs
+++ b/src/CloudStorageORM/Infrastructure/CloudStorageTypeMappingSource.cs
@@ -6,6 +6,9 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace CloudStorageORM.Infrastructure;
 
+/// <summary>
+/// Type-mapping source that adapts EF Core mappings for CloudStorageORM entity payloads.
+/// </summary>
 public class CloudStorageTypeMappingSource(
     TypeMappingSourceDependencies dependencies,
     CloudStorageOptions cloudOptions)

--- a/src/CloudStorageORM/Options/CloudStorageAwsOptions.cs
+++ b/src/CloudStorageORM/Options/CloudStorageAwsOptions.cs
@@ -1,10 +1,32 @@
 namespace CloudStorageORM.Options;
 
+/// <summary>
+/// AWS S3-specific configuration.
+/// </summary>
 public class CloudStorageAwsOptions
 {
+    /// <summary>
+    /// Gets or sets the AWS access key identifier.
+    /// </summary>
     public string AccessKeyId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the AWS secret access key.
+    /// </summary>
     public string SecretAccessKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the AWS region name.
+    /// </summary>
     public string Region { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the S3 service URL, typically used for LocalStack or other S3-compatible endpoints.
+    /// </summary>
     public string ServiceUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether path-style access should be used.
+    /// </summary>
     public bool ForcePathStyle { get; set; } = true;
 }

--- a/src/CloudStorageORM/Options/CloudStorageAzureOptions.cs
+++ b/src/CloudStorageORM/Options/CloudStorageAzureOptions.cs
@@ -1,6 +1,12 @@
 namespace CloudStorageORM.Options;
 
+/// <summary>
+/// Azure Blob Storage-specific configuration.
+/// </summary>
 public class CloudStorageAzureOptions
 {
+    /// <summary>
+    /// Gets or sets the Azure Storage connection string.
+    /// </summary>
     public string ConnectionString { get; set; } = string.Empty;
 }

--- a/src/CloudStorageORM/Options/CloudStorageOptions.cs
+++ b/src/CloudStorageORM/Options/CloudStorageOptions.cs
@@ -3,11 +3,38 @@ using CloudStorageORM.Observability;
 
 namespace CloudStorageORM.Options;
 
+/// <summary>
+/// Root configuration model used by <c>UseCloudStorageOrm(...)</c> and DI registration.
+/// </summary>
 public class CloudStorageOptions
 {
+    /// <summary>
+    /// Gets or sets the selected cloud provider.
+    /// </summary>
     public CloudProvider Provider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the container or bucket name used for object storage.
+    /// </summary>
     public string ContainerName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets retry settings for shared provider I/O boundaries.
+    /// </summary>
+    public CloudStorageRetryOptions Retry { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets Azure-specific options.
+    /// </summary>
     public CloudStorageAzureOptions Azure { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets AWS-specific options.
+    /// </summary>
     public CloudStorageAwsOptions Aws { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets observability options.
+    /// </summary>
     public CloudStorageOrmObservabilityOptions Observability { get; set; } = new();
 }

--- a/src/CloudStorageORM/Options/CloudStorageRetryOptions.cs
+++ b/src/CloudStorageORM/Options/CloudStorageRetryOptions.cs
@@ -1,0 +1,32 @@
+namespace CloudStorageORM.Options;
+
+/// <summary>
+/// Configures transient-fault retries for provider I/O executed by shared CloudStorageORM infrastructure.
+/// </summary>
+public class CloudStorageRetryOptions
+{
+    /// <summary>
+    /// Enables retry execution for transient failures. Defaults to disabled for explicit opt-in.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Maximum number of retry attempts after the initial attempt.
+    /// </summary>
+    public int MaxRetries { get; set; } = 3;
+
+    /// <summary>
+    /// Base delay used by exponential backoff.
+    /// </summary>
+    public TimeSpan BaseDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Maximum delay cap for exponential backoff.
+    /// </summary>
+    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Jitter factor in the range [0, 1]. Zero disables jitter.
+    /// </summary>
+    public double JitterFactor { get; set; } = 0.2d;
+}

--- a/src/CloudStorageORM/Providers/Aws/StorageProviders/AwsS3StorageProvider.cs
+++ b/src/CloudStorageORM/Providers/Aws/StorageProviders/AwsS3StorageProvider.cs
@@ -23,6 +23,10 @@ public class AwsS3StorageProvider : IStorageProvider
     private readonly IAmazonS3 _s3Client;
     private readonly SemaphoreSlim _bucketInitLock = new(1, 1);
     private bool _isBucketInitialized;
+    private static readonly JsonSerializerOptions ReadSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
 
     private static Func<CloudStorageOptions, IAmazonS3> OptionsS3ClientFactory { get; set; } = options =>
     {
@@ -181,12 +185,12 @@ public class AwsS3StorageProvider : IStorageProvider
             var etag = response.ETag;
             if (!string.IsNullOrWhiteSpace(etag))
             {
-                return new StorageObject<T>(JsonSerializer.Deserialize<T>(json), etag, true);
+                return new StorageObject<T>(JsonSerializer.Deserialize<T>(json, ReadSerializerOptions), etag, true);
             }
 
             etag = await GetObjectETagAsync(path);
 
-            return new StorageObject<T>(JsonSerializer.Deserialize<T>(json), etag, true);
+            return new StorageObject<T>(JsonSerializer.Deserialize<T>(json, ReadSerializerOptions), etag, true);
         }
         catch (AmazonS3Exception ex) when (
             ex.StatusCode == HttpStatusCode.NotFound ||

--- a/src/CloudStorageORM/Providers/Azure/StorageProviders/AzureBlobStorageProvider.cs
+++ b/src/CloudStorageORM/Providers/Azure/StorageProviders/AzureBlobStorageProvider.cs
@@ -18,6 +18,10 @@ public class AzureBlobStorageProvider : IStorageProvider
 {
     private readonly BlobContainerClient _containerClient;
     private const string DevelopmentStorageConnectionString = "UseDevelopmentStorage=true";
+    private static readonly JsonSerializerOptions ReadSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
 
     private static Func<CloudStorageOptions, BlobContainerClient> OptionsContainerClientFactory { get; set; }
         = options => new BlobContainerClient(
@@ -147,7 +151,7 @@ public class AzureBlobStorageProvider : IStorageProvider
 
         var response = await blobClient.DownloadContentAsync();
         var etag = await TryGetBlobETagAsync(blobClient);
-        var entity = JsonSerializer.Deserialize<T>(response.Value.Content.ToString());
+        var entity = JsonSerializer.Deserialize<T>(response.Value.Content.ToString(), ReadSerializerOptions);
         return new StorageObject<T>(entity, etag, true);
     }
 

--- a/src/CloudStorageORM/Validators/CloudStorageOptionsValidator.cs
+++ b/src/CloudStorageORM/Validators/CloudStorageOptionsValidator.cs
@@ -34,6 +34,8 @@ public static class CloudStorageOptionsValidator
             throw new InvalidOperationException("CloudStorageOptions.ContainerName must be provided.");
         }
 
+        ValidateRetryOptions(options);
+
         switch (options.Provider)
         {
             case CloudProvider.Azure:
@@ -44,6 +46,40 @@ public static class CloudStorageOptionsValidator
                 break;
             default:
                 throw new NotSupportedException($"Provider {options.Provider} not supported.");
+        }
+    }
+
+    private static void ValidateRetryOptions(CloudStorageOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options.Retry);
+
+        if (options.Retry.MaxRetries < 0)
+        {
+            throw new InvalidOperationException(
+                "CloudStorageOptions.Retry.MaxRetries must be greater than or equal to zero.");
+        }
+
+        if (options.Retry.BaseDelay < TimeSpan.Zero)
+        {
+            throw new InvalidOperationException(
+                "CloudStorageOptions.Retry.BaseDelay must be greater than or equal to zero.");
+        }
+
+        if (options.Retry.MaxDelay < TimeSpan.Zero)
+        {
+            throw new InvalidOperationException(
+                "CloudStorageOptions.Retry.MaxDelay must be greater than or equal to zero.");
+        }
+
+        if (options.Retry.MaxDelay < options.Retry.BaseDelay)
+        {
+            throw new InvalidOperationException(
+                "CloudStorageOptions.Retry.MaxDelay must be greater than or equal to BaseDelay.");
+        }
+
+        if (options.Retry.JitterFactor is < 0d or > 1d)
+        {
+            throw new InvalidOperationException("CloudStorageOptions.Retry.JitterFactor must be between 0 and 1.");
         }
     }
 

--- a/tests/CloudStorageORM.IntegrationTests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
+++ b/tests/CloudStorageORM.IntegrationTests/Aws/StorageProviders/AwsS3StorageProviderTests.cs
@@ -1,12 +1,21 @@
 using System.ComponentModel.DataAnnotations;
+using CloudStorageORM.Abstractions;
 using CloudStorageORM.Enums;
 using CloudStorageORM.Extensions;
 using CloudStorageORM.Infrastructure;
 using CloudStorageORM.IntegrationTests.Aws;
+using CloudStorageORM.Interfaces.StorageProviders;
 using CloudStorageORM.Options;
 using CloudStorageORM.Providers.Aws.StorageProviders;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
 using Shouldly;
+
+// ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedParameter.Local
+// ReSharper disable PropertyCanBeMadeInitOnly.Local
 
 namespace CloudStorageORM.IntegrationTests.AWS.Aws.StorageProviders;
 
@@ -131,6 +140,71 @@ public class AwsS3StorageProviderTests(LocalStackFixture fixture) : IClassFixtur
         await Should.ThrowAsync<DbUpdateConcurrencyException>(() => transaction.CommitAsync());
     }
 
+    [Fact]
+    public async Task RetryEnabled_SaveChangesAndPrimaryKeyQuery_RecoverFromInjectedTransientFailure()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (innerProvider, bucketName) = await CreateIsolatedProviderAsync(fixture, "retry");
+        var options = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Aws,
+            ContainerName = bucketName,
+            Aws = new CloudStorageAwsOptions
+            {
+                AccessKeyId = fixture.AccessKeyId,
+                SecretAccessKey = fixture.SecretAccessKey,
+                Region = fixture.Region,
+                ServiceUrl = fixture.ServiceUrl,
+                ForcePathStyle = true
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = true,
+                MaxRetries = 2,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero,
+                JitterFactor = 0
+            }
+        };
+
+        var flakyProvider = new TransientOnceStorageProvider(innerProvider, failSaveOnce: true, failReadOnce: true);
+        var dbContextOptions = new DbContextOptionsBuilder<RetryHarnessDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new RetryHarnessDbContext(dbContextOptions);
+
+        var database = new CloudStorageDatabase(
+            context.Model,
+            new NoOpDatabaseCreator(),
+            new NoOpExecutionStrategyFactory(),
+            flakyProvider,
+            new CurrentDbContextStub(context),
+            new BlobPathResolver(flakyProvider),
+            new CloudStorageTransactionManager(),
+            options);
+
+        var entity = new RetryHarnessEntity { Id = $"retry-{Guid.NewGuid():N}", Name = "before" };
+        context.Add(entity);
+        var entries = context
+            .ChangeTracker
+            .Entries()
+            .Select(e => (IUpdateEntry)e.GetInfrastructure())
+            .ToList();
+
+        var saved = await database.SaveChangesAsync(entries);
+        saved.ShouldBe(1);
+
+        var queryProvider = new CloudStorageQueryProvider(database, new BlobPathResolver(flakyProvider));
+        var queryable = new CloudStorageQueryable<RetryHarnessEntity>(queryProvider);
+        var loaded = queryable.FirstOrDefault(x => x.Id == entity.Id);
+
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("before");
+        flakyProvider.SaveAttempts.ShouldBeGreaterThanOrEqualTo(2);
+        flakyProvider.ReadAttempts.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
     private static AwsTransactionalTestDbContext CreateTransactionContext(LocalStackFixture fixture, string bucketName)
     {
         var options = new DbContextOptionsBuilder<AwsTransactionalTestDbContext>()
@@ -190,14 +264,11 @@ public class AwsS3StorageProviderTests(LocalStackFixture fixture) : IClassFixtur
 
     private sealed class AwsTransactionalEntity
     {
-        [MaxLength(100)]
-        public string Id { get; init; } = string.Empty;
+        [MaxLength(100)] public string Id { get; init; } = string.Empty;
 
-        [MaxLength(100)]
-        public string Name { get; set; } = string.Empty;
+        [MaxLength(100)] public string Name { get; set; } = string.Empty;
 
-        [MaxLength(256)]
-        public string? ETag { get; set; }
+        [MaxLength(256)] public string? ETag { get; set; }
     }
 
     private sealed class AwsTransactionalTestDbContext(DbContextOptions<AwsTransactionalTestDbContext> options)
@@ -208,5 +279,127 @@ public class AwsS3StorageProviderTests(LocalStackFixture fixture) : IClassFixtur
             modelBuilder.Entity<AwsTransactionalEntity>().HasKey(x => x.Id);
             modelBuilder.Entity<AwsTransactionalEntity>().UseObjectETagConcurrency();
         }
+    }
+
+    private sealed class RetryHarnessDbContext(DbContextOptions<RetryHarnessDbContext> options) : DbContext(options)
+    {
+        public DbSet<RetryHarnessEntity> Entities => Set<RetryHarnessEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<RetryHarnessEntity>().HasKey(x => x.Id);
+        }
+    }
+
+    private sealed class RetryHarnessEntity
+    {
+        [MaxLength(100)] public string Id { get; init; } = string.Empty;
+
+        [MaxLength(100)] public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class TransientOnceStorageProvider(
+        IStorageProvider inner,
+        bool failSaveOnce,
+        bool failReadOnce) : IStorageProvider
+    {
+        private int _saveFailuresRemaining = failSaveOnce ? 1 : 0;
+        private int _readFailuresRemaining = failReadOnce ? 1 : 0;
+
+        public int SaveAttempts { get; private set; }
+        public int ReadAttempts { get; private set; }
+
+        public CloudProvider CloudProvider => inner.CloudProvider;
+
+        public Task DeleteContainerAsync() => inner.DeleteContainerAsync();
+
+        public Task CreateContainerIfNotExistsAsync() => inner.CreateContainerIfNotExistsAsync();
+
+        public async Task SaveAsync<T>(string path, T entity)
+        {
+            SaveAttempts++;
+            if (_saveFailuresRemaining > 0)
+            {
+                _saveFailuresRemaining--;
+                throw new HttpRequestException("Injected transient save failure.");
+            }
+
+            await inner.SaveAsync(path, entity);
+        }
+
+        public async Task<string?> SaveAsync<T>(string path, T entity, string? ifMatchETag)
+        {
+            SaveAttempts++;
+            if (_saveFailuresRemaining > 0)
+            {
+                _saveFailuresRemaining--;
+                throw new HttpRequestException("Injected transient save failure.");
+            }
+
+            return await inner.SaveAsync(path, entity, ifMatchETag);
+        }
+
+        public Task<T> ReadAsync<T>(string path) => inner.ReadAsync<T>(path);
+
+        public async Task<StorageObject<T>> ReadWithMetadataAsync<T>(string path)
+        {
+            ReadAttempts++;
+            if (_readFailuresRemaining > 0)
+            {
+                _readFailuresRemaining--;
+                throw new HttpRequestException("Injected transient read failure.");
+            }
+
+            return await inner.ReadWithMetadataAsync<T>(path);
+        }
+
+        public Task DeleteAsync(string path) => inner.DeleteAsync(path);
+
+        public Task DeleteAsync(string path, string? ifMatchETag) => inner.DeleteAsync(path, ifMatchETag);
+
+        public Task<List<string>> ListAsync(string folderPath) => inner.ListAsync(folderPath);
+
+        public Task<StorageListPage> ListPageAsync(
+            string folderPath,
+            int pageSize,
+            string? continuationToken,
+            CancellationToken cancellationToken = default)
+        {
+            return inner.ListPageAsync(folderPath, pageSize, continuationToken, cancellationToken);
+        }
+
+        public string SanitizeBlobName(string rawName) => inner.SanitizeBlobName(rawName);
+    }
+
+    private sealed class NoOpDatabaseCreator : IDatabaseCreator
+    {
+        public bool EnsureDeleted() => true;
+
+        public Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public bool EnsureCreated() => true;
+
+        public Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public bool CanConnect() => true;
+
+        public Task<bool> CanConnectAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public bool HasTables() => true;
+
+        public Task<bool> HasTablesAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+    }
+
+    private sealed class NoOpExecutionStrategyFactory : IExecutionStrategyFactory
+    {
+        public IExecutionStrategy Create()
+        {
+            throw new NotSupportedException("Execution strategy is not used by this integration harness.");
+        }
+    }
+
+    private sealed class CurrentDbContextStub(DbContext context) : ICurrentDbContext
+    {
+        public DbContext Context => context;
     }
 }

--- a/tests/CloudStorageORM.IntegrationTests/Aws/Transactions/AwsTransactionFailureWindowTests.cs
+++ b/tests/CloudStorageORM.IntegrationTests/Aws/Transactions/AwsTransactionFailureWindowTests.cs
@@ -1,0 +1,287 @@
+using System.ComponentModel.DataAnnotations;
+using CloudStorageORM.Enums;
+using CloudStorageORM.Extensions;
+using CloudStorageORM.Infrastructure;
+using CloudStorageORM.IntegrationTests.Aws;
+using CloudStorageORM.Options;
+using CloudStorageORM.Providers.Aws.StorageProviders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+// ReSharper disable UnusedMember.Local
+
+namespace CloudStorageORM.IntegrationTests.AWS.Aws.Transactions;
+
+public class AwsTransactionFailureWindowTests(LocalStackFixture fixture) : IClassFixture<LocalStackFixture>
+{
+    [Fact]
+    public async Task RollbackWindow_SaveChangesThenRollback_DoesNotPersistEntity()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, bucketName) = await CreateIsolatedProviderAsync("rollback");
+        await using var context = CreateContext(bucketName);
+
+        var entity = new AwsTxEntity { Id = $"rb-{Guid.NewGuid():N}", Name = "rollback" };
+        context.Add(entity);
+
+        await using var tx = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+        await tx.RollbackAsync();
+
+        var path = new BlobPathResolver(provider).GetPath(typeof(AwsTxEntity), entity.Id);
+        var loaded = await provider.ReadAsync<AwsTxEntity>(path);
+        loaded.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CommitWindow_SaveChangesThenCommit_PersistsEntity()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, bucketName) = await CreateIsolatedProviderAsync("commit");
+        await using var context = CreateContext(bucketName);
+
+        var entity = new AwsTxEntity { Id = $"cm-{Guid.NewGuid():N}", Name = "commit" };
+        context.Add(entity);
+
+        await using var tx = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+        await tx.CommitAsync();
+
+        var path = new BlobPathResolver(provider).GetPath(typeof(AwsTxEntity), entity.Id);
+        var loaded = await provider.ReadAsync<AwsTxEntity>(path);
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(entity.Id);
+    }
+
+    [Fact]
+    public async Task RecoveryWindow_CommittedManifest_ReplaysAndCompletes()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, _) = await CreateIsolatedProviderAsync("recovery");
+        var txId = Guid.NewGuid();
+        var entityId = $"rc-{Guid.NewGuid():N}";
+        var entityPath = new BlobPathResolver(provider).GetPath(typeof(AwsTxEntity), entityId);
+        var manifestPath = $"__cloudstorageorm/tx/{txId:D}/manifest.json";
+
+        await provider.SaveAsync(manifestPath, new RecoveryManifest
+        {
+            TransactionId = txId,
+            State = 1,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            CommittedAtUtc = DateTimeOffset.UtcNow,
+            AppliedOperationCount = 0,
+            Operations =
+            [
+                new RecoveryOperation
+                {
+                    Sequence = 0,
+                    Kind = 0,
+                    Path = entityPath,
+                    PayloadJson = $"{{\"id\":\"{entityId}\",\"name\":\"Recovered\"}}"
+                }
+            ]
+        });
+
+        var manager = new CloudStorageTransactionManager(provider);
+        await manager.BeginTransactionAsync();
+        await manager.RollbackTransactionAsync();
+
+        var loaded = await provider.ReadAsync<AwsTxEntity>(entityPath);
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("Recovered");
+
+        var replayedManifest = await provider.ReadAsync<RecoveryManifest>(manifestPath);
+        replayedManifest.State.ShouldBe(2);
+        replayedManifest.AppliedOperationCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CrossWriterConflictWindow_CommitAfterExternalUpdate_ThrowsConcurrencyException()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, bucketName) = await CreateIsolatedProviderAsync("conflict");
+        var id = $"cf-{Guid.NewGuid():N}";
+        var path = new BlobPathResolver(provider).GetPath(typeof(AwsTxEntity), id);
+
+        await provider.SaveAsync(path, new AwsTxEntity { Id = id, Name = "v1" });
+        var original = await provider.ReadWithMetadataAsync<AwsTxEntity>(path);
+
+        await using var context = CreateContext(bucketName);
+        var tracked = new AwsTxEntity { Id = id, Name = "tx-update", ETag = original.ETag };
+        context.Attach(tracked);
+        context.Entry(tracked).Property(x => x.ETag).OriginalValue = original.ETag;
+        context.Entry(tracked).State = EntityState.Modified;
+
+        await using var tx = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+
+        await provider.SaveAsync(path, new AwsTxEntity { Id = id, Name = "v2" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => tx.CommitAsync());
+    }
+
+    [Fact]
+    public async Task CrossWriterConflictWindow_EmitsTransactionAndConcurrencyEvents()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var logCollector = new EventIdLogCollector();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.ClearProviders();
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddProvider(new EventIdLoggerProvider(logCollector));
+        });
+
+        var (provider, bucketName) = await CreateIsolatedProviderAsync("obs");
+        var id = $"obs-{Guid.NewGuid():N}";
+        var path = new BlobPathResolver(provider).GetPath(typeof(AwsTxEntity), id);
+
+        await provider.SaveAsync(path, new AwsTxEntity { Id = id, Name = "v1" });
+        var original = await provider.ReadWithMetadataAsync<AwsTxEntity>(path);
+
+        await using var context = CreateContext(bucketName, loggerFactory);
+        var tracked = new AwsTxEntity { Id = id, Name = "tx-update", ETag = original.ETag };
+        context.Attach(tracked);
+        context.Entry(tracked).Property(x => x.ETag).OriginalValue = original.ETag;
+        context.Entry(tracked).State = EntityState.Modified;
+
+        await using var tx = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+        await provider.SaveAsync(path, new AwsTxEntity { Id = id, Name = "v2" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => tx.CommitAsync());
+
+        logCollector.EventIds.ShouldContain(Observability.CloudStorageOrmEventIds.TransactionBeginning);
+        logCollector.EventIds.ShouldContain(Observability.CloudStorageOrmEventIds.ConcurrencyConflict);
+    }
+
+    private AwsTxDbContext CreateContext(string bucketName, ILoggerFactory? loggerFactory = null)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<AwsTxDbContext>()
+            .UseCloudStorageOrm(cfg =>
+            {
+                cfg.Provider = CloudProvider.Aws;
+                cfg.ContainerName = bucketName;
+                cfg.Aws = new CloudStorageAwsOptions
+                {
+                    AccessKeyId = fixture.AccessKeyId,
+                    SecretAccessKey = fixture.SecretAccessKey,
+                    Region = fixture.Region,
+                    ServiceUrl = fixture.ServiceUrl,
+                    ForcePathStyle = true
+                };
+            });
+
+        if (loggerFactory is not null)
+        {
+            optionsBuilder.UseLoggerFactory(loggerFactory);
+        }
+
+        var options = optionsBuilder.Options;
+
+        return new AwsTxDbContext(options);
+    }
+
+    private async Task<(AwsS3StorageProvider Provider, string BucketName)> CreateIsolatedProviderAsync(string scenario)
+    {
+        var rawBucketName = $"tx-{scenario}-{Guid.NewGuid():N}";
+        var bucketName = rawBucketName.Length <= 45 ? rawBucketName : rawBucketName[..45];
+        var options = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Aws,
+            ContainerName = bucketName,
+            Aws = new CloudStorageAwsOptions
+            {
+                AccessKeyId = fixture.AccessKeyId,
+                SecretAccessKey = fixture.SecretAccessKey,
+                Region = fixture.Region,
+                ServiceUrl = fixture.ServiceUrl,
+                ForcePathStyle = true
+            }
+        };
+
+        var provider = new AwsS3StorageProvider(options);
+        await provider.CreateContainerIfNotExistsAsync();
+        return (provider, bucketName);
+    }
+
+    private sealed class AwsTxDbContext(DbContextOptions<AwsTxDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<AwsTxEntity>().HasKey(x => x.Id);
+            modelBuilder.Entity<AwsTxEntity>().UseObjectETagConcurrency();
+        }
+    }
+
+    private sealed class AwsTxEntity
+    {
+        [MaxLength(100)] public string Id { get; init; } = string.Empty;
+
+        [MaxLength(100)] public string Name { get; init; } = string.Empty;
+
+        [MaxLength(256)] public string? ETag { get; init; }
+    }
+
+    private sealed class RecoveryManifest
+    {
+        public Guid TransactionId { get; set; }
+        public int State { get; init; }
+        public DateTimeOffset CreatedAtUtc { get; set; }
+        public DateTimeOffset? CommittedAtUtc { get; set; }
+        public DateTimeOffset? CompletedAtUtc { get; set; }
+        public List<RecoveryOperation> Operations { get; set; } = [];
+        public int AppliedOperationCount { get; init; }
+    }
+
+    private sealed class RecoveryOperation
+    {
+        public int Sequence { get; set; }
+        public int Kind { get; set; }
+        public string Path { get; set; } = string.Empty;
+        public string? PayloadJson { get; set; }
+        public string? IfMatchETag { get; set; }
+    }
+
+    private sealed class EventIdLogCollector
+    {
+        public List<EventId> EventIds { get; } = [];
+    }
+
+    private sealed class EventIdLoggerProvider(EventIdLogCollector collector) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new EventIdLogger(collector);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class EventIdLogger(EventIdLogCollector collector) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            collector.EventIds.Add(eventId);
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/CloudStorageORM.IntegrationTests/Azure/StorageProviders/AzureBlobStorageProviderTests.cs
+++ b/tests/CloudStorageORM.IntegrationTests/Azure/StorageProviders/AzureBlobStorageProviderTests.cs
@@ -1,11 +1,20 @@
 using System.ComponentModel.DataAnnotations;
+using CloudStorageORM.Abstractions;
 using CloudStorageORM.Enums;
 using CloudStorageORM.Extensions;
 using CloudStorageORM.Infrastructure;
+using CloudStorageORM.Interfaces.StorageProviders;
 using CloudStorageORM.Options;
 using CloudStorageORM.Providers.Azure.StorageProviders;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
 using Shouldly;
+
+// ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedParameter.Local
+// ReSharper disable PropertyCanBeMadeInitOnly.Local
 
 namespace CloudStorageORM.IntegrationTests.Azure.Azure.StorageProviders;
 
@@ -129,7 +138,69 @@ public class AzureBlobStorageProviderTests(StorageFixture fixture) : IClassFixtu
         await Should.ThrowAsync<DbUpdateConcurrencyException>(() => transaction.CommitAsync());
     }
 
-    private static AzureTransactionalTestDbContext CreateTransactionContext(string connectionString, string containerName)
+    [Fact]
+    public async Task RetryEnabled_SaveChangesAndPrimaryKeyQuery_RecoverFromInjectedTransientFailure()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (innerProvider, containerName) = await CreateIsolatedProviderAsync(fixture, "retry");
+        var options = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Azure,
+            ContainerName = containerName,
+            Azure = new CloudStorageAzureOptions
+            {
+                ConnectionString = fixture.ConnectionString
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = true,
+                MaxRetries = 2,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero,
+                JitterFactor = 0
+            }
+        };
+
+        var flakyProvider = new TransientOnceStorageProvider(innerProvider, failSaveOnce: true, failReadOnce: true);
+        var dbContextOptions = new DbContextOptionsBuilder<RetryHarnessDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new RetryHarnessDbContext(dbContextOptions);
+
+        var database = new CloudStorageDatabase(
+            context.Model,
+            new NoOpDatabaseCreator(),
+            new NoOpExecutionStrategyFactory(),
+            flakyProvider,
+            new CurrentDbContextStub(context),
+            new BlobPathResolver(flakyProvider),
+            new CloudStorageTransactionManager(),
+            options);
+
+        var entity = new RetryHarnessEntity { Id = $"retry-{Guid.NewGuid():N}", Name = "before" };
+        context.Add(entity);
+        var entries = context
+            .ChangeTracker
+            .Entries()
+            .Select(e => (IUpdateEntry)e.GetInfrastructure())
+            .ToList();
+
+        var saved = await database.SaveChangesAsync(entries);
+        saved.ShouldBe(1);
+
+        var queryProvider = new CloudStorageQueryProvider(database, new BlobPathResolver(flakyProvider));
+        var queryable = new CloudStorageQueryable<RetryHarnessEntity>(queryProvider);
+        var loaded = queryable.FirstOrDefault(x => x.Id == entity.Id);
+
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("before");
+        flakyProvider.SaveAttempts.ShouldBeGreaterThanOrEqualTo(2);
+        flakyProvider.ReadAttempts.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    private static AzureTransactionalTestDbContext CreateTransactionContext(string connectionString,
+        string containerName)
     {
         var options = new DbContextOptionsBuilder<AzureTransactionalTestDbContext>()
             .UseCloudStorageOrm(cfg =>
@@ -175,12 +246,131 @@ public sealed class AzureTransactionalTestDbContext(DbContextOptions<AzureTransa
 
 public sealed class TransactionTestEntity
 {
-    [MaxLength(100)]
-    public string Id { get; init; } = string.Empty;
+    [MaxLength(100)] public string Id { get; init; } = string.Empty;
 
-    [MaxLength(100)]
-    public string Name { get; set; } = string.Empty;
+    [MaxLength(100)] public string Name { get; set; } = string.Empty;
 
-    [MaxLength(256)]
-    public string? ETag { get; set; }
+    [MaxLength(256)] public string? ETag { get; set; }
+}
+
+public sealed class RetryHarnessDbContext(DbContextOptions<RetryHarnessDbContext> options) : DbContext(options)
+{
+    public DbSet<RetryHarnessEntity> Entities => Set<RetryHarnessEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<RetryHarnessEntity>().HasKey(x => x.Id);
+    }
+}
+
+public sealed class RetryHarnessEntity
+{
+    [MaxLength(100)] public string Id { get; init; } = string.Empty;
+
+    [MaxLength(100)] public string Name { get; set; } = string.Empty;
+}
+
+internal sealed class TransientOnceStorageProvider(
+    IStorageProvider inner,
+    bool failSaveOnce,
+    bool failReadOnce) : IStorageProvider
+{
+    private int _saveFailuresRemaining = failSaveOnce ? 1 : 0;
+    private int _readFailuresRemaining = failReadOnce ? 1 : 0;
+
+    public int SaveAttempts { get; private set; }
+    public int ReadAttempts { get; private set; }
+
+    public CloudProvider CloudProvider => inner.CloudProvider;
+
+    public Task DeleteContainerAsync() => inner.DeleteContainerAsync();
+
+    public Task CreateContainerIfNotExistsAsync() => inner.CreateContainerIfNotExistsAsync();
+
+    public async Task SaveAsync<T>(string path, T entity)
+    {
+        SaveAttempts++;
+        if (_saveFailuresRemaining > 0)
+        {
+            _saveFailuresRemaining--;
+            throw new HttpRequestException("Injected transient save failure.");
+        }
+
+        await inner.SaveAsync(path, entity);
+    }
+
+    public async Task<string?> SaveAsync<T>(string path, T entity, string? ifMatchETag)
+    {
+        SaveAttempts++;
+        if (_saveFailuresRemaining > 0)
+        {
+            _saveFailuresRemaining--;
+            throw new HttpRequestException("Injected transient save failure.");
+        }
+
+        return await inner.SaveAsync(path, entity, ifMatchETag);
+    }
+
+    public Task<T> ReadAsync<T>(string path) => inner.ReadAsync<T>(path);
+
+    public async Task<StorageObject<T>> ReadWithMetadataAsync<T>(string path)
+    {
+        ReadAttempts++;
+        if (_readFailuresRemaining > 0)
+        {
+            _readFailuresRemaining--;
+            throw new HttpRequestException("Injected transient read failure.");
+        }
+
+        return await inner.ReadWithMetadataAsync<T>(path);
+    }
+
+    public Task DeleteAsync(string path) => inner.DeleteAsync(path);
+
+    public Task DeleteAsync(string path, string? ifMatchETag) => inner.DeleteAsync(path, ifMatchETag);
+
+    public Task<List<string>> ListAsync(string folderPath) => inner.ListAsync(folderPath);
+
+    public Task<StorageListPage> ListPageAsync(
+        string folderPath,
+        int pageSize,
+        string? continuationToken,
+        CancellationToken cancellationToken = default)
+    {
+        return inner.ListPageAsync(folderPath, pageSize, continuationToken, cancellationToken);
+    }
+
+    public string SanitizeBlobName(string rawName) => inner.SanitizeBlobName(rawName);
+}
+
+internal sealed class NoOpDatabaseCreator : IDatabaseCreator
+{
+    public bool EnsureDeleted() => true;
+
+    public Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+    public bool EnsureCreated() => true;
+
+    public Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+    public bool CanConnect() => true;
+
+    public Task<bool> CanConnectAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+    public bool HasTables() => true;
+
+    public Task<bool> HasTablesAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+}
+
+internal sealed class NoOpExecutionStrategyFactory : IExecutionStrategyFactory
+{
+    public IExecutionStrategy Create()
+    {
+        throw new NotSupportedException("Execution strategy is not used by this integration harness.");
+    }
+}
+
+internal sealed class CurrentDbContextStub(DbContext context) : ICurrentDbContext
+{
+    public DbContext Context => context;
 }

--- a/tests/CloudStorageORM.IntegrationTests/Azure/Transactions/AzureTransactionFailureWindowTests.cs
+++ b/tests/CloudStorageORM.IntegrationTests/Azure/Transactions/AzureTransactionFailureWindowTests.cs
@@ -1,0 +1,268 @@
+using System.ComponentModel.DataAnnotations;
+using CloudStorageORM.Enums;
+using CloudStorageORM.Extensions;
+using CloudStorageORM.Infrastructure;
+using CloudStorageORM.Options;
+using CloudStorageORM.Providers.Azure.StorageProviders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+// ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+
+namespace CloudStorageORM.IntegrationTests.Azure.Azure.Transactions;
+
+public class AzureTransactionFailureWindowTests(StorageFixture fixture) : IClassFixture<StorageFixture>
+{
+    [Fact]
+    public async Task RollbackWindow_SaveChangesThenRollback_DoesNotPersistEntity()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, containerName) = await CreateIsolatedProviderAsync("rollback");
+        await using var context = CreateContext(containerName);
+
+        var entity = new AzureTxEntity { Id = $"rb-{Guid.NewGuid():N}", Name = "rollback" };
+        context.Add(entity);
+
+        await using var tx = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+        await tx.RollbackAsync();
+
+        var path = new BlobPathResolver(provider).GetPath(typeof(AzureTxEntity), entity.Id);
+        var loaded = await provider.ReadAsync<AzureTxEntity>(path);
+        loaded.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CommitWindow_SaveChangesThenCommit_PersistsEntity()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, containerName) = await CreateIsolatedProviderAsync("commit");
+        await using var context = CreateContext(containerName);
+
+        var entity = new AzureTxEntity { Id = $"cm-{Guid.NewGuid():N}", Name = "commit" };
+        context.Add(entity);
+
+        await using var tx = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+        await tx.CommitAsync();
+
+        var path = new BlobPathResolver(provider).GetPath(typeof(AzureTxEntity), entity.Id);
+        var loaded = await provider.ReadAsync<AzureTxEntity>(path);
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(entity.Id);
+    }
+
+    [Fact]
+    public async Task RecoveryWindow_CommittedManifest_ReplaysAndCompletes()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, _) = await CreateIsolatedProviderAsync("recovery");
+        var txId = Guid.NewGuid();
+        var entityId = $"rc-{Guid.NewGuid():N}";
+        var entityPath = new BlobPathResolver(provider).GetPath(typeof(AzureTxEntity), entityId);
+        var manifestPath = $"__cloudstorageorm/tx/{txId:D}/manifest.json";
+
+        await provider.SaveAsync(manifestPath, new RecoveryManifest
+        {
+            TransactionId = txId,
+            State = 1,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            CommittedAtUtc = DateTimeOffset.UtcNow,
+            AppliedOperationCount = 0,
+            Operations =
+            [
+                new RecoveryOperation
+                {
+                    Sequence = 0,
+                    Kind = 0,
+                    Path = entityPath,
+                    PayloadJson = $"{{\"id\":\"{entityId}\",\"name\":\"Recovered\"}}"
+                }
+            ]
+        });
+
+        var manager = new CloudStorageTransactionManager(provider);
+        await manager.BeginTransactionAsync();
+        await manager.RollbackTransactionAsync();
+
+        var loaded = await provider.ReadAsync<AzureTxEntity>(entityPath);
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("Recovered");
+
+        var replayedManifest = await provider.ReadAsync<RecoveryManifest>(manifestPath);
+        replayedManifest.State.ShouldBe(2);
+        replayedManifest.AppliedOperationCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CrossWriterConflictWindow_CommitAfterExternalUpdate_ThrowsConcurrencyException()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var (provider, containerName) = await CreateIsolatedProviderAsync("conflict");
+        var id = $"cf-{Guid.NewGuid():N}";
+        var path = new BlobPathResolver(provider).GetPath(typeof(AzureTxEntity), id);
+
+        await provider.SaveAsync(path, new AzureTxEntity { Id = id, Name = "v1" });
+        var original = await provider.ReadWithMetadataAsync<AzureTxEntity>(path);
+
+        await using var context = CreateContext(containerName);
+        var tracked = new AzureTxEntity { Id = id, Name = "tx-update", ETag = original.ETag };
+        context.Attach(tracked);
+        context.Entry(tracked).Property(x => x.ETag).OriginalValue = original.ETag;
+        context.Entry(tracked).State = EntityState.Modified;
+
+        await using var tx = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+
+        await provider.SaveAsync(path, new AzureTxEntity { Id = id, Name = "v2" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => tx.CommitAsync());
+    }
+
+    [Fact]
+    public async Task CrossWriterConflictWindow_EmitsTransactionAndConcurrencyEvents()
+    {
+        fixture.EnsureAvailableOrSkip();
+
+        var logCollector = new EventIdLogCollector();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.ClearProviders();
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddProvider(new EventIdLoggerProvider(logCollector));
+        });
+
+        var (provider, containerName) = await CreateIsolatedProviderAsync("obs");
+        var id = $"obs-{Guid.NewGuid():N}";
+        var path = new BlobPathResolver(provider).GetPath(typeof(AzureTxEntity), id);
+
+        await provider.SaveAsync(path, new AzureTxEntity { Id = id, Name = "v1" });
+        var original = await provider.ReadWithMetadataAsync<AzureTxEntity>(path);
+
+        await using var context = CreateContext(containerName, loggerFactory);
+        var tracked = new AzureTxEntity { Id = id, Name = "tx-update", ETag = original.ETag };
+        context.Attach(tracked);
+        context.Entry(tracked).Property(x => x.ETag).OriginalValue = original.ETag;
+        context.Entry(tracked).State = EntityState.Modified;
+
+        await using var tx = await context.Database.BeginTransactionAsync();
+        await context.SaveChangesAsync();
+        await provider.SaveAsync(path, new AzureTxEntity { Id = id, Name = "v2" });
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => tx.CommitAsync());
+
+        logCollector.EventIds.ShouldContain(Observability.CloudStorageOrmEventIds.TransactionBeginning);
+        logCollector.EventIds.ShouldContain(Observability.CloudStorageOrmEventIds.ConcurrencyConflict);
+    }
+
+    private AzureTxDbContext CreateContext(string containerName, ILoggerFactory? loggerFactory = null)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<AzureTxDbContext>()
+            .UseCloudStorageOrm(cfg =>
+            {
+                cfg.Provider = CloudProvider.Azure;
+                cfg.ContainerName = containerName;
+                cfg.Azure = new CloudStorageAzureOptions
+                {
+                    ConnectionString = fixture.ConnectionString
+                };
+            });
+
+        if (loggerFactory is not null)
+        {
+            optionsBuilder.UseLoggerFactory(loggerFactory);
+        }
+
+        var options = optionsBuilder.Options;
+
+        return new AzureTxDbContext(options);
+    }
+
+    private async Task<(AzureBlobStorageProvider Provider, string ContainerName)> CreateIsolatedProviderAsync(
+        string scenario)
+    {
+        var containerName = $"tx-{scenario}-{Guid.NewGuid():N}"[..30];
+        var provider = new AzureBlobStorageProvider(fixture.ConnectionString, containerName);
+        await provider.CreateContainerIfNotExistsAsync();
+        return (provider, containerName);
+    }
+
+    private sealed class AzureTxDbContext(DbContextOptions<AzureTxDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<AzureTxEntity>().HasKey(x => x.Id);
+            modelBuilder.Entity<AzureTxEntity>().UseObjectETagConcurrency();
+        }
+    }
+
+    private sealed class AzureTxEntity
+    {
+        [MaxLength(100)] public string Id { get; init; } = string.Empty;
+
+        [MaxLength(100)] public string Name { get; init; } = string.Empty;
+
+        [MaxLength(256)] public string? ETag { get; init; }
+    }
+
+    private sealed class RecoveryManifest
+    {
+        public Guid TransactionId { get; set; }
+        public int State { get; init; }
+        public DateTimeOffset CreatedAtUtc { get; set; }
+        public DateTimeOffset? CommittedAtUtc { get; set; }
+        public DateTimeOffset? CompletedAtUtc { get; set; }
+        public List<RecoveryOperation> Operations { get; set; } = [];
+        public int AppliedOperationCount { get; init; }
+    }
+
+    private sealed class RecoveryOperation
+    {
+        public int Sequence { get; set; }
+        public int Kind { get; set; }
+        public string Path { get; set; } = string.Empty;
+        public string? PayloadJson { get; set; }
+        public string? IfMatchETag { get; set; }
+    }
+
+    private sealed class EventIdLogCollector
+    {
+        public List<EventId> EventIds { get; } = [];
+    }
+
+    private sealed class EventIdLoggerProvider(EventIdLogCollector collector) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new EventIdLogger(collector);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class EventIdLogger(EventIdLogCollector collector) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            collector.EventIds.Add(eventId);
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.AWS.csproj
+++ b/tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.AWS.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <LangVersion>14</LangVersion>
+        <NoWarn>$(NoWarn);EF1001</NoWarn>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>
 
@@ -25,6 +26,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -33,8 +35,7 @@
 
     <ItemGroup>
         <Compile Include="IntegrationTestSkip.cs"/>
-        <Compile Include="Aws/LocalStackFixture.cs"/>
-        <Compile Include="Aws/StorageProviders/**/*.cs"/>
+        <Compile Include="Aws/**/*.cs"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj
+++ b/tests/CloudStorageORM.IntegrationTests/CloudStorageORM.IntegrationTests.Azure.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <LangVersion>14</LangVersion>
+        <NoWarn>$(NoWarn);EF1001</NoWarn>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>
 
@@ -25,6 +26,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -33,8 +35,7 @@
 
     <ItemGroup>
         <Compile Include="IntegrationTestSkip.cs"/>
-        <Compile Include="Azure/StorageFixture.cs"/>
-        <Compile Include="Azure/StorageProviders/**/*.cs"/>
+        <Compile Include="Azure/**/*.cs"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/CloudStorageORM.Tests/Extensions/CloudStorageOrmOptionsExtensionInfoTests.cs
+++ b/tests/CloudStorageORM.Tests/Extensions/CloudStorageOrmOptionsExtensionInfoTests.cs
@@ -86,4 +86,66 @@ public class CloudStorageOrmOptionsExtensionInfoTests
 
         info.Extension.ShouldBeSameAs(extension);
     }
+
+    [Fact]
+    public void GetServiceProviderHashCode_ChangesWhenRetryConfigurationChanges()
+    {
+        var baseline = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Azure,
+            ContainerName = "test",
+            Azure = new CloudStorageAzureOptions
+            {
+                ConnectionString = "UseDevelopmentStorage=true"
+            }
+        };
+        var withRetry = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Azure,
+            ContainerName = "test",
+            Azure = new CloudStorageAzureOptions
+            {
+                ConnectionString = "UseDevelopmentStorage=true"
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = true,
+                MaxRetries = 6,
+                BaseDelay = TimeSpan.FromMilliseconds(20),
+                MaxDelay = TimeSpan.FromMilliseconds(250),
+                JitterFactor = 0.5
+            }
+        };
+
+        var baselineInfo = new CloudStorageOrmOptionsExtensionInfo(new CloudStorageOrmOptionsExtension(baseline));
+        var retryInfo = new CloudStorageOrmOptionsExtensionInfo(new CloudStorageOrmOptionsExtension(withRetry));
+
+        baselineInfo.GetServiceProviderHashCode().ShouldNotBe(retryInfo.GetServiceProviderHashCode());
+    }
+
+    [Fact]
+    public void PopulateDebugInfo_IncludesRetryConfiguration()
+    {
+        var extension = new CloudStorageOrmOptionsExtension(new CloudStorageOptions
+        {
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = true,
+                MaxRetries = 4,
+                BaseDelay = TimeSpan.FromMilliseconds(50),
+                MaxDelay = TimeSpan.FromMilliseconds(500),
+                JitterFactor = 0.25
+            }
+        });
+        var info = new CloudStorageOrmOptionsExtensionInfo(extension);
+        var debug = new Dictionary<string, string>();
+
+        info.PopulateDebugInfo(debug);
+
+        debug["CloudStorageORM:Retry:Enabled"].ShouldBe("True");
+        debug["CloudStorageORM:Retry:MaxRetries"].ShouldBe("4");
+        debug.ShouldContainKey("CloudStorageORM:Retry:BaseDelayMs");
+        debug.ShouldContainKey("CloudStorageORM:Retry:MaxDelayMs");
+        debug["CloudStorageORM:Retry:JitterFactor"].ShouldBe("0.25");
+    }
 }

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageDatabaseTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageDatabaseTests.cs
@@ -1,10 +1,12 @@
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using CloudStorageORM.Abstractions;
+using CloudStorageORM.Enums;
 using CloudStorageORM.Extensions;
 using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Interfaces.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
+using CloudStorageORM.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -87,6 +89,76 @@ public class CloudStorageDatabaseTests
 
         changes.ShouldBe(1);
         fixture.StorageProviderMock.Verify(x => x.DeleteAsync("users/3.json"), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_AddedEntry_RetriesTransientFailure_WhenEnabled()
+    {
+        var fixture = CreateFixture(new CloudStorageOptions
+        {
+            Provider = CloudProvider.Azure,
+            ContainerName = "tests",
+            Azure = new CloudStorageAzureOptions
+            {
+                ConnectionString = "UseDevelopmentStorage=true"
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = true,
+                MaxRetries = 2,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero,
+                JitterFactor = 0
+            }
+        });
+
+        var entity = new DbUser { Id = "retry-add", Name = "Retry" };
+        fixture.Context.Add(entity);
+        var entries = GetUpdateEntries(fixture.Context);
+        fixture.PathResolverMock.Setup(x => x.GetPath(It.IsAny<IUpdateEntry>())).Returns("users/retry-add.json");
+        fixture.StorageProviderMock
+            .SetupSequence(x => x.SaveAsync("users/retry-add.json", It.IsAny<object>()))
+            .ThrowsAsync(new HttpRequestException("temporary"))
+            .Returns(Task.CompletedTask);
+
+        var changes = await fixture.Database.SaveChangesAsync(entries);
+
+        changes.ShouldBe(1);
+        fixture.StorageProviderMock.Verify(x => x.SaveAsync("users/retry-add.json", It.IsAny<object>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_AddedEntry_DoesNotRetryTransientFailure_WhenDisabled()
+    {
+        var fixture = CreateFixture(new CloudStorageOptions
+        {
+            Provider = CloudProvider.Azure,
+            ContainerName = "tests",
+            Azure = new CloudStorageAzureOptions
+            {
+                ConnectionString = "UseDevelopmentStorage=true"
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = false,
+                MaxRetries = 3,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero,
+                JitterFactor = 0
+            }
+        });
+
+        var entity = new DbUser { Id = "retry-disabled", Name = "Retry" };
+        fixture.Context.Add(entity);
+        var entries = GetUpdateEntries(fixture.Context);
+        fixture.PathResolverMock.Setup(x => x.GetPath(It.IsAny<IUpdateEntry>())).Returns("users/retry-disabled.json");
+        fixture.StorageProviderMock
+            .Setup(x => x.SaveAsync("users/retry-disabled.json", It.IsAny<object>()))
+            .ThrowsAsync(new HttpRequestException("temporary"));
+
+        await Should.ThrowAsync<HttpRequestException>(() => fixture.Database.SaveChangesAsync(entries));
+
+        fixture.StorageProviderMock.Verify(x => x.SaveAsync("users/retry-disabled.json", It.IsAny<object>()), Times.Once);
     }
 
     [Fact]
@@ -260,7 +332,7 @@ public class CloudStorageDatabaseTests
     [Fact]
     public async Task LoadEntitiesAsync_UsesBlobNameFromResolver()
     {
-        const string dbUsers = "dbusers";
+        const string dbUsers = "db-users";
         var fixture = CreateFixture();
         fixture.PathResolverMock.Setup(x => x.GetBlobName(typeof(DbUser))).Returns(dbUsers);
         fixture.StorageProviderMock.Setup(x => x.ListAsync(dbUsers)).ReturnsAsync([]);
@@ -535,7 +607,7 @@ public class CloudStorageDatabaseTests
             Expression.Quote(predicate));
     }
 
-    private static DatabaseFixture CreateFixture()
+    private static DatabaseFixture CreateFixture(CloudStorageOptions? cloudStorageOptions = null)
     {
         var dbOptions = new DbContextOptionsBuilder<DatabaseTestDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -566,7 +638,8 @@ public class CloudStorageDatabaseTests
             storageProviderMock.Object,
             currentDbContextMock.Object,
             pathResolverMock.Object,
-            transactionManager);
+            transactionManager,
+            cloudStorageOptions);
 
         return new DatabaseFixture(
             database,

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageDbContextDependencies.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageDbContextDependencies.cs
@@ -27,6 +27,8 @@ public class CloudStorageDbContextDependenciesTests
         IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger,
         IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger)
     {
+        var transactionManager = new Mock<IDbContextTransactionManager>().Object;
+
         return new CloudStorageDbContextDependencies(
             model,
             currentContext,
@@ -37,6 +39,7 @@ public class CloudStorageDbContextDependenciesTests
             queryProvider,
             stateManager,
             exceptionDetector,
+            transactionManager,
             updateLogger,
             infrastructureLogger
         );
@@ -311,6 +314,38 @@ public class CloudStorageDbContextDependenciesTests
     }
 
     [Fact]
+    public void Constructor_WithNullTransactionManager_ThrowsArgumentNullException()
+    {
+        var modelMock = new Mock<IModel>().Object;
+        var currentContextMock = new Mock<ICurrentDbContext>().Object;
+        var changeDetectorMock = new Mock<IChangeDetector>().Object;
+        var setSourceMock = new Mock<IDbSetSource>().Object;
+        var entityFinderSourceMock = new Mock<IEntityFinderSource>().Object;
+        var entityGraphAttacherMock = new Mock<IEntityGraphAttacher>().Object;
+        var queryProviderMock = new Mock<IAsyncQueryProvider>().Object;
+        var stateManagerMock = new Mock<IStateManager>().Object;
+        var exceptionDetectorMock = new Mock<IExceptionDetector>().Object;
+        var updateLoggerMock = new Mock<IDiagnosticsLogger<DbLoggerCategory.Update>>().Object;
+        var infrastructureLoggerMock = new Mock<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>().Object;
+
+        var exception = Should.Throw<ArgumentNullException>(() => new CloudStorageDbContextDependencies(
+            modelMock,
+            currentContextMock,
+            changeDetectorMock,
+            setSourceMock,
+            entityFinderSourceMock,
+            entityGraphAttacherMock,
+            queryProviderMock,
+            stateManagerMock,
+            exceptionDetectorMock,
+            null!,
+            updateLoggerMock,
+            infrastructureLoggerMock));
+
+        exception.ParamName.ShouldBe("transactionManager");
+    }
+
+    [Fact]
     public void Constructor_WithNullInfrastructureLogger_ThrowsArgumentNullException()
     {
         var dependencies = CreateValidDependencies();
@@ -346,6 +381,7 @@ public class CloudStorageDbContextDependenciesTests
         var queryProviderMock = new Mock<IAsyncQueryProvider>().Object;
         var stateManagerMock = new Mock<IStateManager>().Object;
         var exceptionDetectorMock = new Mock<IExceptionDetector>().Object;
+        var transactionManagerMock = new Mock<IDbContextTransactionManager>().Object;
         var updateLoggerMock = new Mock<IDiagnosticsLogger<DbLoggerCategory.Update>>().Object;
         var infrastructureLoggerMock = new Mock<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>().Object;
 
@@ -359,6 +395,7 @@ public class CloudStorageDbContextDependenciesTests
             queryProviderMock,
             stateManagerMock,
             exceptionDetectorMock,
+            transactionManagerMock,
             updateLoggerMock,
             infrastructureLoggerMock);
 
@@ -375,11 +412,12 @@ public class CloudStorageDbContextDependenciesTests
     }
 
     [Fact]
-    public void TransactionManager_ShouldReturnInstanceOfCloudStorageTransactionManager()
+    public void TransactionManager_WithInjectedManager_ReturnsSameInstance()
     {
         var dependencies = CreateValidDependencies();
+        var transactionManager = new Mock<IDbContextTransactionManager>().Object;
 
-        var sut = MakeSut(
+        var sut = new CloudStorageDbContextDependencies(
             dependencies.Item1,
             dependencies.Item2,
             dependencies.Item3,
@@ -389,10 +427,11 @@ public class CloudStorageDbContextDependenciesTests
             dependencies.Item7,
             dependencies.Item8,
             dependencies.Item9,
+            transactionManager,
             dependencies.Item10,
             dependencies.Item11
         );
 
-        sut.TransactionManager.ShouldBeOfType<CloudStorageTransactionManager>();
+        sut.TransactionManager.ShouldBe(transactionManager);
     }
 }

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageQueryProviderTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageQueryProviderTests.cs
@@ -4,6 +4,7 @@ using CloudStorageORM.Abstractions;
 using CloudStorageORM.Enums;
 using CloudStorageORM.Infrastructure;
 using CloudStorageORM.Interfaces.StorageProviders;
+using CloudStorageORM.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -23,9 +24,9 @@ public class CloudStorageQueryProviderTests
     private const string UserId2 = "user-2";
 
     private static (CloudStorageQueryProvider provider, Mock<IStorageProvider> storageProviderMock)
-        BuildProvider(List<QueryTestUser>? seed = null)
+        BuildProvider(List<QueryTestUser>? seed = null, CloudStorageOptions? cloudStorageOptions = null)
     {
-        seed ??= new List<QueryTestUser>();
+        seed ??= [];
         var storageProviderMock = new Mock<IStorageProvider>();
         storageProviderMock.Setup(x => x.CloudProvider).Returns(CloudProvider.Azure);
         storageProviderMock.Setup(x => x.SanitizeBlobName(It.IsAny<string>()))
@@ -55,13 +56,13 @@ public class CloudStorageQueryProviderTests
                 .ReturnsAsync(new StorageObject<QueryTestUser?>(user, "etag", true));
         }
 
-        var database = BuildDatabase(storageProviderMock.Object);
+        var database = BuildDatabase(storageProviderMock.Object, cloudStorageOptions);
         var provider = new CloudStorageQueryProvider(database, pathResolver);
         return (provider, storageProviderMock);
     }
 
     private static (CloudStorageQueryProvider provider, Mock<IStorageProvider> storageProviderMock)
-        BuildRangeProvider(List<RangeQueryTestUser>? seed = null)
+        BuildRangeProvider(List<RangeQueryTestUser>? seed = null, CloudStorageOptions? cloudStorageOptions = null)
     {
         seed ??= [];
         var storageProviderMock = new Mock<IStorageProvider>();
@@ -90,12 +91,14 @@ public class CloudStorageQueryProviderTests
                 .ReturnsAsync(new StorageObject<RangeQueryTestUser?>(user, "etag", true));
         }
 
-        var database = BuildRangeDatabase(storageProviderMock.Object);
+        var database = BuildRangeDatabase(storageProviderMock.Object, cloudStorageOptions);
         var provider = new CloudStorageQueryProvider(database, pathResolver);
         return (provider, storageProviderMock);
     }
 
-    private static CloudStorageDatabase BuildDatabase(IStorageProvider storageProvider)
+    private static CloudStorageDatabase BuildDatabase(
+        IStorageProvider storageProvider,
+        CloudStorageOptions? cloudStorageOptions = null)
     {
         var options = new DbContextOptionsBuilder<MinimalDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -143,10 +146,13 @@ public class CloudStorageQueryProviderTests
             storageProvider,
             currentDbContextMock.Object,
             new BlobPathResolver(storageProvider),
-            new CloudStorageTransactionManager());
+            new CloudStorageTransactionManager(),
+            cloudStorageOptions);
     }
 
-    private static CloudStorageDatabase BuildRangeDatabase(IStorageProvider storageProvider)
+    private static CloudStorageDatabase BuildRangeDatabase(
+        IStorageProvider storageProvider,
+        CloudStorageOptions? cloudStorageOptions = null)
     {
         var options = new DbContextOptionsBuilder<RangeMinimalDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -186,7 +192,92 @@ public class CloudStorageQueryProviderTests
             storageProvider,
             currentDbContextMock.Object,
             new BlobPathResolver(storageProvider),
-            new CloudStorageTransactionManager());
+            new CloudStorageTransactionManager(),
+            cloudStorageOptions);
+    }
+
+    [Fact]
+    public void FirstOrDefault_WithTransientReadError_Retries_WhenEnabled()
+    {
+        var retryOptions = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Azure,
+            ContainerName = "tests",
+            Azure = new CloudStorageAzureOptions
+            {
+                ConnectionString = "UseDevelopmentStorage=true"
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = true,
+                MaxRetries = 2,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero,
+                JitterFactor = 0
+            }
+        };
+
+        var seed = new List<QueryTestUser>
+        {
+            new() { Id = UserId1, Name = "Alice" }
+        };
+
+        var (provider, storageMock) = BuildProvider(seed, retryOptions);
+        var pathResolver = new BlobPathResolver(storageMock.Object);
+        var blobName = pathResolver.GetBlobName(typeof(QueryTestUser));
+        var targetPath = $"{blobName}/{UserId1}.json";
+
+        storageMock
+            .SetupSequence(x => x.ReadWithMetadataAsync<QueryTestUser>(targetPath))
+            .ThrowsAsync(new HttpRequestException("temporary"))
+            .ReturnsAsync(new StorageObject<QueryTestUser>(seed[0], "etag", true));
+
+        var queryable = new CloudStorageQueryable<QueryTestUser>(provider);
+        var result = queryable.FirstOrDefault(u => u.Id == UserId1);
+
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(UserId1);
+        storageMock.Verify(x => x.ReadWithMetadataAsync<QueryTestUser>(targetPath), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void FirstOrDefault_WithTransientReadError_DoesNotRetry_WhenDisabled()
+    {
+        var retryOptions = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Azure,
+            ContainerName = "tests",
+            Azure = new CloudStorageAzureOptions
+            {
+                ConnectionString = "UseDevelopmentStorage=true"
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = false,
+                MaxRetries = 2,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero,
+                JitterFactor = 0
+            }
+        };
+
+        var seed = new List<QueryTestUser>
+        {
+            new() { Id = UserId1, Name = "Alice" }
+        };
+
+        var (provider, storageMock) = BuildProvider(seed, retryOptions);
+        var pathResolver = new BlobPathResolver(storageMock.Object);
+        var blobName = pathResolver.GetBlobName(typeof(QueryTestUser));
+        var targetPath = $"{blobName}/{UserId1}.json";
+
+        storageMock
+            .Setup(x => x.ReadWithMetadataAsync<QueryTestUser>(targetPath))
+            .ThrowsAsync(new HttpRequestException("temporary"));
+
+        var queryable = new CloudStorageQueryable<QueryTestUser>(provider);
+        Should.Throw<HttpRequestException>(() => queryable.FirstOrDefault(u => u.Id == UserId1));
+        storageMock.Verify(x => x.ReadWithMetadataAsync<QueryTestUser>(targetPath), Times.Once);
     }
 
     [Fact]

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageRetryExecutorTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageRetryExecutorTests.cs
@@ -1,0 +1,125 @@
+using CloudStorageORM.Infrastructure;
+using CloudStorageORM.Options;
+using Shouldly;
+
+namespace CloudStorageORM.Tests.Infrastructure;
+
+public class CloudStorageRetryExecutorTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WithRetryEnabled_RetriesTransientFailureUntilSuccess()
+    {
+        var options = new CloudStorageRetryOptions
+        {
+            Enabled = true,
+            MaxRetries = 3,
+            BaseDelay = TimeSpan.Zero,
+            MaxDelay = TimeSpan.Zero,
+            JitterFactor = 0
+        };
+
+        var attempts = 0;
+        var executor = new CloudStorageRetryExecutor(
+            options,
+            _ => true,
+            static (_, _) => Task.CompletedTask,
+            static () => 0.5d);
+
+        await executor.ExecuteAsync(async _ =>
+        {
+            attempts++;
+            if (attempts < 3)
+            {
+                throw new HttpRequestException("temporary");
+            }
+
+            await Task.CompletedTask;
+        });
+
+        attempts.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithRetryDisabled_DoesNotRetry()
+    {
+        var options = new CloudStorageRetryOptions
+        {
+            Enabled = false,
+            MaxRetries = 5,
+            BaseDelay = TimeSpan.Zero,
+            MaxDelay = TimeSpan.Zero,
+            JitterFactor = 0
+        };
+
+        var attempts = 0;
+        var executor = new CloudStorageRetryExecutor(
+            options,
+            _ => true,
+            static (_, _) => Task.CompletedTask,
+            static () => 0.5d);
+
+        await Should.ThrowAsync<HttpRequestException>(() => executor.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new HttpRequestException("temporary");
+        }));
+
+        attempts.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNonTransientException_DoesNotRetry()
+    {
+        var options = new CloudStorageRetryOptions
+        {
+            Enabled = true,
+            MaxRetries = 5,
+            BaseDelay = TimeSpan.Zero,
+            MaxDelay = TimeSpan.Zero,
+            JitterFactor = 0
+        };
+
+        var attempts = 0;
+        var executor = new CloudStorageRetryExecutor(
+            options,
+            _ => false,
+            static (_, _) => Task.CompletedTask,
+            static () => 0.5d);
+
+        await Should.ThrowAsync<InvalidOperationException>(() => executor.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException("non-transient");
+        }));
+
+        attempts.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StopsAtConfiguredRetryBudget()
+    {
+        var options = new CloudStorageRetryOptions
+        {
+            Enabled = true,
+            MaxRetries = 2,
+            BaseDelay = TimeSpan.Zero,
+            MaxDelay = TimeSpan.Zero,
+            JitterFactor = 0
+        };
+
+        var attempts = 0;
+        var executor = new CloudStorageRetryExecutor(
+            options,
+            _ => true,
+            static (_, _) => Task.CompletedTask,
+            static () => 0.5d);
+
+        await Should.ThrowAsync<HttpRequestException>(() => executor.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new HttpRequestException("temporary");
+        }));
+
+        attempts.ShouldBe(3);
+    }
+}

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransactionManagerObservabilityTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransactionManagerObservabilityTests.cs
@@ -1,0 +1,189 @@
+using System.Text.Json;
+using CloudStorageORM.Abstractions;
+using CloudStorageORM.Enums;
+using CloudStorageORM.Infrastructure;
+using CloudStorageORM.Interfaces.StorageProviders;
+using CloudStorageORM.Observability;
+using CloudStorageORM.Options;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+// ReSharper disable NotAccessedPositionalProperty.Local
+
+namespace CloudStorageORM.Tests.Infrastructure;
+
+public class CloudStorageTransactionManagerObservabilityTests
+{
+    [Fact]
+    public async Task BeginAndCommit_WhenLoggingEnabled_EmitsTransactionEvents()
+    {
+        var logger = new RecordingLogger<CloudStorageTransactionManager>();
+        var manager = new CloudStorageTransactionManager(
+            storageProvider: null,
+            cloudStorageOptions: new CloudStorageOptions
+            {
+                Retry = new CloudStorageRetryOptions(),
+                Observability = new CloudStorageOrmObservabilityOptions { EnableLogging = true, EnableTracing = false }
+            },
+            logger: logger);
+
+        await manager.BeginTransactionAsync();
+        manager.EnqueueOperation(_ => Task.CompletedTask);
+        await manager.CommitTransactionAsync();
+
+        logger.Entries.ShouldContain(x => x.EventId == CloudStorageOrmEventIds.TransactionBeginning);
+        logger.Entries.ShouldContain(x => x.EventId == CloudStorageOrmEventIds.TransactionCommitted);
+    }
+
+    [Fact]
+    public async Task BeginAndRollback_WhenLoggingDisabled_DoesNotEmitTransactionEvents()
+    {
+        var logger = new RecordingLogger<CloudStorageTransactionManager>();
+        var manager = new CloudStorageTransactionManager(
+            storageProvider: null,
+            cloudStorageOptions: new CloudStorageOptions
+            {
+                Retry = new CloudStorageRetryOptions(),
+                Observability = new CloudStorageOrmObservabilityOptions { EnableLogging = false, EnableTracing = false }
+            },
+            logger: logger);
+
+        await manager.BeginTransactionAsync();
+        await manager.RollbackTransactionAsync();
+
+        logger.Entries.ShouldNotContain(x => x.EventId == CloudStorageOrmEventIds.TransactionBeginning);
+        logger.Entries.ShouldNotContain(x => x.EventId == CloudStorageOrmEventIds.TransactionRolledBack);
+    }
+
+    [Fact]
+    public async Task DurableCommit_WhenConditionalWriteConflicts_LogsConcurrencyConflict()
+    {
+        var logger = new RecordingLogger<CloudStorageTransactionManager>();
+        var storage = new ObservabilityStorageProvider { ForcePreconditionFailureOnConditionalWrite = true };
+        var manager = new CloudStorageTransactionManager(
+            storage,
+            new CloudStorageOptions
+            {
+                Retry = new CloudStorageRetryOptions(),
+                Observability = new CloudStorageOrmObservabilityOptions { EnableLogging = true, EnableTracing = false }
+            },
+            logger);
+
+        var tx = await manager.BeginTransactionAsync();
+        await manager.StageSaveOperationAsync("users/conflict.json", new { Id = "1" }, "etag-old",
+            CancellationToken.None);
+
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => tx.CommitAsync());
+
+        logger.Entries.ShouldContain(x => x.EventId == CloudStorageOrmEventIds.ConcurrencyConflict);
+        logger.Entries.ShouldContain(x => x.EventId == CloudStorageOrmEventIds.BlobUploadStarting);
+    }
+
+    private sealed class ObservabilityStorageProvider : IStorageProvider
+    {
+        private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+        private readonly Dictionary<string, string> _store = new(StringComparer.Ordinal);
+        public bool ForcePreconditionFailureOnConditionalWrite { get; set; }
+
+        public CloudProvider CloudProvider => CloudProvider.Azure;
+
+        public Task DeleteContainerAsync()
+        {
+            _store.Clear();
+            return Task.CompletedTask;
+        }
+
+        public Task CreateContainerIfNotExistsAsync() => Task.CompletedTask;
+
+        public Task SaveAsync<T>(string path, T entity)
+        {
+            _store[path] = JsonSerializer.Serialize(entity, _jsonOptions);
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> SaveAsync<T>(string path, T entity, string? ifMatchETag)
+        {
+            if (ForcePreconditionFailureOnConditionalWrite && !string.IsNullOrWhiteSpace(ifMatchETag))
+            {
+                throw new StoragePreconditionFailedException(path);
+            }
+
+            _store[path] = JsonSerializer.Serialize(entity, _jsonOptions);
+            return Task.FromResult<string?>("etag-new");
+        }
+
+        public Task<T> ReadAsync<T>(string path)
+        {
+            return Task.FromResult(!_store.TryGetValue(path, out var json)
+                ? default!
+                : JsonSerializer.Deserialize<T>(json, _jsonOptions)!)!;
+        }
+
+        public async Task<StorageObject<T>> ReadWithMetadataAsync<T>(string path)
+        {
+            var value = await ReadAsync<T>(path);
+            var exists = !EqualityComparer<T>.Default.Equals(value, default!);
+            return new StorageObject<T>(value, exists ? "etag" : null, exists);
+        }
+
+        public Task DeleteAsync(string path)
+        {
+            _store.Remove(path);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAsync(string path, string? ifMatchETag)
+        {
+            if (ForcePreconditionFailureOnConditionalWrite && !string.IsNullOrWhiteSpace(ifMatchETag))
+            {
+                throw new StoragePreconditionFailedException(path);
+            }
+
+            _store.Remove(path);
+            return Task.CompletedTask;
+        }
+
+        public Task<List<string>> ListAsync(string folderPath)
+        {
+            var keys = _store.Keys.Where(k => k.StartsWith(folderPath, StringComparison.Ordinal)).ToList();
+            return Task.FromResult(keys);
+        }
+
+        public Task<StorageListPage> ListPageAsync(string folderPath, int pageSize, string? continuationToken,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new StorageListPage([], null, false));
+        }
+
+        public string SanitizeBlobName(string rawName) => rawName;
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(eventId, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record LogEntry(
+        EventId EventId,
+        string Message,
+        Exception? Exception);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransientExceptionClassifierTests.cs
+++ b/tests/CloudStorageORM.Tests/Infrastructure/CloudStorageTransientExceptionClassifierTests.cs
@@ -1,0 +1,48 @@
+using CloudStorageORM.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace CloudStorageORM.Tests.Infrastructure;
+
+public class CloudStorageTransientExceptionClassifierTests
+{
+    [Fact]
+    public void IsTransient_WithHttpRequestException_ReturnsTrue()
+    {
+        CloudStorageTransientExceptionClassifier.IsTransient(new HttpRequestException("network")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsTransient_WithTimeoutException_ReturnsTrue()
+    {
+        CloudStorageTransientExceptionClassifier.IsTransient(new TimeoutException("timeout")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsTransient_WithStoragePreconditionFailedException_ReturnsFalse()
+    {
+        CloudStorageTransientExceptionClassifier.IsTransient(new StoragePreconditionFailedException("users/1.json"))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsTransient_WithDbUpdateConcurrencyException_ReturnsFalse()
+    {
+        CloudStorageTransientExceptionClassifier.IsTransient(new DbUpdateConcurrencyException("conflict"))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsTransient_WithWrappedTransientException_ReturnsTrue()
+    {
+        var wrapped = new InvalidOperationException("wrapper", new HttpRequestException("network"));
+
+        CloudStorageTransientExceptionClassifier.IsTransient(wrapped).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsTransient_WithNonTransientException_ReturnsFalse()
+    {
+        CloudStorageTransientExceptionClassifier.IsTransient(new InvalidOperationException("fatal")).ShouldBeFalse();
+    }
+}

--- a/tests/CloudStorageORM.Tests/Options/CloudStorageOptionsTests.cs
+++ b/tests/CloudStorageORM.Tests/Options/CloudStorageOptionsTests.cs
@@ -39,7 +39,42 @@ public class CloudStorageOptionsTests
 
         options.Azure.ShouldNotBeNull();
         options.Aws.ShouldNotBeNull();
+        options.Retry.ShouldNotBeNull();
         options.Observability.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void RetryOptions_DefaultToExplicitOptInWithBoundedValues()
+    {
+        var options = new CloudStorageOptions();
+
+        options.Retry.Enabled.ShouldBeFalse();
+        options.Retry.MaxRetries.ShouldBe(3);
+        options.Retry.BaseDelay.ShouldBe(TimeSpan.FromMilliseconds(100));
+        options.Retry.MaxDelay.ShouldBe(TimeSpan.FromSeconds(2));
+        options.Retry.JitterFactor.ShouldBe(0.2d);
+    }
+
+    [Fact]
+    public void RetryOptions_AreAssignable()
+    {
+        var options = new CloudStorageOptions
+        {
+            Retry =
+            {
+                Enabled = true,
+                MaxRetries = 5,
+                BaseDelay = TimeSpan.FromMilliseconds(150),
+                MaxDelay = TimeSpan.FromSeconds(1),
+                JitterFactor = 0.4d
+            }
+        };
+
+        options.Retry.Enabled.ShouldBeTrue();
+        options.Retry.MaxRetries.ShouldBe(5);
+        options.Retry.BaseDelay.ShouldBe(TimeSpan.FromMilliseconds(150));
+        options.Retry.MaxDelay.ShouldBe(TimeSpan.FromSeconds(1));
+        options.Retry.JitterFactor.ShouldBe(0.4d);
     }
 
     [Fact]

--- a/tests/CloudStorageORM.Tests/Validators/CloudStorageOptionsValidatorTests.cs
+++ b/tests/CloudStorageORM.Tests/Validators/CloudStorageOptionsValidatorTests.cs
@@ -95,4 +95,75 @@ public class CloudStorageOptionsValidatorTests
         var ex = Should.Throw<InvalidOperationException>(() => CloudStorageOptionsValidator.Validate(options));
         ex.Message.ShouldContain("ContainerName");
     }
+
+    [Fact]
+    public void Validate_WithRetryEnabledAndValidBounds_DoesNotThrow()
+    {
+        var options = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Azure,
+            ContainerName = "unit-container",
+            Azure = new CloudStorageAzureOptions
+            {
+                ConnectionString = "UseDevelopmentStorage=true"
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = true,
+                MaxRetries = 4,
+                BaseDelay = TimeSpan.FromMilliseconds(25),
+                MaxDelay = TimeSpan.FromMilliseconds(250),
+                JitterFactor = 0.3
+            }
+        };
+
+        Should.NotThrow(() => CloudStorageOptionsValidator.Validate(options));
+    }
+
+    [Fact]
+    public void Validate_WithNegativeRetryMaxRetries_Throws()
+    {
+        var options = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Azure,
+            ContainerName = "unit-container",
+            Azure = new CloudStorageAzureOptions
+            {
+                ConnectionString = "UseDevelopmentStorage=true"
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = true,
+                MaxRetries = -1
+            }
+        };
+
+        var ex = Should.Throw<InvalidOperationException>(() => CloudStorageOptionsValidator.Validate(options));
+        ex.Message.ShouldContain("Retry.MaxRetries");
+    }
+
+    [Fact]
+    public void Validate_WithRetryMaxDelayLowerThanBaseDelay_Throws()
+    {
+        var options = new CloudStorageOptions
+        {
+            Provider = CloudProvider.Aws,
+            ContainerName = "unit-bucket",
+            Aws = new CloudStorageAwsOptions
+            {
+                AccessKeyId = "test-key",
+                SecretAccessKey = "test-secret",
+                Region = "us-east-1"
+            },
+            Retry = new CloudStorageRetryOptions
+            {
+                Enabled = true,
+                BaseDelay = TimeSpan.FromMilliseconds(200),
+                MaxDelay = TimeSpan.FromMilliseconds(100)
+            }
+        };
+
+        var ex = Should.Throw<InvalidOperationException>(() => CloudStorageOptionsValidator.Validate(options));
+        ex.Message.ShouldContain("Retry.MaxDelay");
+    }
 }


### PR DESCRIPTION
# Pull Request

## 📋 Description
This PR completes the P0 correctness/recoverability work and updates the documentation to match the current implementation.

### Implemented / fixed
- Added configurable transient-fault retries with bounded exponential backoff and jitter at the shared persistence/query execution boundary.
- Kept provider-specific behavior unchanged while applying retries in the shared infrastructure layer.
- Completed runtime observability wiring across save, query, transaction, and recovery paths.
- Added CI-stable Azure and AWS transaction failure-window coverage for:
  - rollback
  - commit
  - crash recovery / committed-manifest replay
  - stale-ETag concurrency conflicts
- Updated the backlog/TODO tracking so only open items remain.
- Refreshed documentation for:
  - retry configuration and behavior
  - observability toggles and diagnostics caveats
  - transaction recovery and failure-window coverage
  - local Azurite / LocalStack test guidance

## 🔎 Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please specify):

## 📚 Checklist
- [x] Code follows project standards
- [x] Tests were added or updated
- [x] Documentation was updated if necessary
- [x] Build and tests are passing